### PR TITLE
Batch enhancements: complete #19 #22 #23

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ A responsive Streamlit prototype for exploring deep sky objects across Messier, 
   - Object metadata
   - Current Alt/Az + 16-wind direction
   - Free-use image lookup (Wikimedia Commons, if available)
-  - Path Plot (Alt vs Az)
-  - Night Plot (hourly max altitude + direction + optional temperature)
+  - Path Plot (Alt vs Az, Line/Radial style, radial Dome View toggle)
+  - Night Plot (hourly stacked max altitude: obstructed + clear, direction + optional temperature)
 - Alt/Az auto-refresh every 60 seconds
 
 ## Project structure


### PR DESCRIPTION
## Summary
- implement #19 by converting the Hourly Forecast into stacked bars where total bar height equals hourly max altitude and segments are split into obstructed vs clear altitude
- implement #22 by adding a `Dome View` toggle for radial sky position plots (center=90 when on, center=0 when off)
- implement #23 by replacing the sky-position style radio with Streamlit segmented control
- update README coverage bullets to document the new plotting behavior

## Validation
- `./.venv/bin/python -m py_compile app.py`
- `./.venv/bin/streamlit run app.py --server.headless true --server.address 127.0.0.1 --server.port 8506` (startup smoke)

Closes #19
Closes #22
Closes #23
