### PR TITLE
Fix #29: add settings export/import workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A responsive Streamlit prototype for exploring deep sky objects across Messier, 
 - Location controls (default Princeton, manual geocode, browser geolocation permission flow, IP fallback)
 - 16-bin obstruction editor (default 20 deg)
 - Favorites and Set List with browser-local persistence (per user/device)
+- Settings export/import via JSON for backup or migration to another machine
 - Catalog ingestion module with normalized schema + disk cache + metadata
 - Target detail panel with:
   - Object metadata


### PR DESCRIPTION
## Summary
- add a sidebar **Settings Backup** section with one-click JSON export of current preferences
- add JSON import flow with validation and overwrite of current preferences
- support importing either exported wrapper payloads (`preferences` field) or raw preference dictionaries
- show clear warnings for missing file, invalid JSON, and unsupported format
- update README coverage to include settings export/import capability

## Validation
- `./.venv/bin/python -m py_compile app.py`
- `./.venv/bin/streamlit run app.py --server.headless true --server.address 127.0.0.1 --server.port 8506` (startup smoke)

Closes #29
