### PR TITLE
Add SIMBAD SH2 ingestion and M/NGC enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Notes:
 
 ## Notes
 
-- Catalog ingest loads full OpenNGC data and augments it with SIMBAD (full SH2 ingest + M/NGC enrichment).
+- Catalog ingest loads full OpenNGC data and augments it with SIMBAD (`NAME` objects are retained, with unmatched rows kept as `SIMBAD` catalog entries).
 - If live ingest fails, the app falls back to the local seed dataset.
 - Use the sidebar `Refresh catalog cache` button to force a re-ingest.
 - Weather and image lookups fail gracefully without breaking plots.


### PR DESCRIPTION
## Summary
- add SIMBAD TAP integration to catalog ingestion with endpoint failover
- ingest SH2 rows from SIMBAD (full Sharpless coverage when SIMBAD is reachable), with fallback to seed SH2 on failure
- enrich M/NGC rows using SIMBAD identifiers/object types/aliases while preserving OpenNGC as baseline
- bump ingestion cache version so existing caches auto-refresh onto the new pipeline
- include SIMBAD ingest/enrichment status details in cache metadata
- update README notes to reflect SIMBAD augmentation

## Validation
- `./.venv/bin/python -m py_compile app.py catalog_ingestion.py scripts/ingest_catalog.py`
- `./.venv/bin/streamlit run app.py --server.headless true --server.address 127.0.0.1 --server.port 8506` (startup smoke)
- `./.venv/bin/python scripts/ingest_catalog.py` (pipeline smoke; in this sandbox SIMBAD host DNS resolution fails, so fallback path was exercised)
