### PR TITLE
Improve radial/search UX and add optional cookie backup for preferences

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,6 +34,13 @@ from streamlit_js_eval import (
     streamlit_js_eval,
 )
 from streamlit_autorefresh import st_autorefresh
+from prefs_cookie_backup import (
+    bootstrap_cookie_backup,
+    get_cookie_backup_notice,
+    read_preferences_cookie_backup,
+    set_cookie_backup_runtime_enabled,
+    write_preferences_cookie_backup,
+)
 from timezonefinder import TimezoneFinder
 
 st.set_page_config(page_title="DSO Explorer", page_icon="✨", layout="wide")
@@ -87,6 +94,9 @@ CATALOG_SEED_PATH = Path("data/dso_catalog_seed.csv")
 CATALOG_CACHE_PATH = Path("data/dso_catalog_cache.parquet")
 CATALOG_META_PATH = Path("data/dso_catalog_cache_meta.json")
 BROWSER_PREFS_STORAGE_KEY = "dso_explorer_prefs_v1"
+ENABLE_COOKIE_BACKUP = True
+PREFS_BOOTSTRAP_MAX_RUNS = 6
+PREFS_BOOTSTRAP_RETRY_INTERVAL_MS = 250
 SETTINGS_EXPORT_FORMAT_VERSION = 1
 
 TEMPERATURE_UNIT_OPTIONS = {
@@ -187,32 +197,94 @@ def decode_preferences_from_storage(raw_value: str) -> dict[str, Any] | None:
         return None
 
 
-def load_preferences() -> dict[str, Any]:
-    raw_value = get_local_storage(BROWSER_PREFS_STORAGE_KEY, component_key="browser_prefs_read")
-    if isinstance(raw_value, str) and raw_value.strip():
-        decoded = decode_preferences_from_storage(raw_value)
+# Optional cookie backup is isolated in `prefs_cookie_backup.py`.
+# Toggle `ENABLE_COOKIE_BACKUP` above to disable it without code removal.
+# Full removal later: delete the `prefs_cookie_backup` import, remove the
+# integration calls below, remove `extra-streamlit-components` from requirements,
+# and delete `prefs_cookie_backup.py`.
+
+
+def load_preferences() -> tuple[dict[str, Any], bool]:
+    retry_needed = False
+    raw_local = get_local_storage(BROWSER_PREFS_STORAGE_KEY, component_key="browser_prefs_read")
+    local_exists_probe = streamlit_js_eval(
+        js_expressions=(
+            "Object.prototype.hasOwnProperty.call(window.localStorage, "
+            + json.dumps(BROWSER_PREFS_STORAGE_KEY)
+            + ")"
+        ),
+        key="browser_prefs_local_exists_probe",
+    )
+
+    if raw_local is None and local_exists_probe is None:
+        retry_needed = True
+
+    if isinstance(raw_local, str) and raw_local.strip():
+        decoded = decode_preferences_from_storage(raw_local)
         if decoded is not None:
             st.session_state.pop("prefs_persistence_notice", None)
-            return decoded
-    return default_preferences()
+            return decoded, False
+    elif local_exists_probe is True:
+        # Local key appears to exist but returned value is unavailable in this pass.
+        retry_needed = True
+
+    raw_cookie = read_preferences_cookie_backup()
+    if isinstance(raw_cookie, str) and raw_cookie.strip():
+        decoded_cookie = decode_preferences_from_storage(raw_cookie)
+        if decoded_cookie is not None:
+            try:
+                payload_hash = hashlib.sha1(raw_cookie.encode("ascii")).hexdigest()[:12]
+                set_local_storage(
+                    BROWSER_PREFS_STORAGE_KEY,
+                    raw_cookie,
+                    component_key=f"browser_prefs_rehydrate_{payload_hash}",
+                )
+            except Exception:
+                pass
+
+            st.session_state.pop("prefs_persistence_notice", None)
+            return decoded_cookie, False
+
+    return default_preferences(), retry_needed
 
 
 def save_preferences(prefs: dict[str, Any]) -> bool:
     try:
         encoded = encode_preferences_for_storage(prefs)
-        payload_hash = hashlib.sha1(encoded.encode("ascii")).hexdigest()[:12]
-        set_local_storage(
-            BROWSER_PREFS_STORAGE_KEY,
-            encoded,
-            component_key=f"browser_prefs_write_{payload_hash}",
-        )
-        st.session_state.pop("prefs_persistence_notice", None)
-        return True
     except Exception:
         st.session_state["prefs_persistence_notice"] = (
             "Browser-local preference storage is unavailable. Using session-only preferences."
         )
         return False
+
+    payload_hash = hashlib.sha1(encoded.encode("ascii")).hexdigest()[:12]
+    local_saved = False
+    try:
+        set_local_storage(
+            BROWSER_PREFS_STORAGE_KEY,
+            encoded,
+            component_key=f"browser_prefs_write_{payload_hash}",
+        )
+        local_saved = True
+    except Exception:
+        local_saved = False
+
+    cookie_saved = write_preferences_cookie_backup(encoded)
+
+    if local_saved:
+        st.session_state.pop("prefs_persistence_notice", None)
+        return True
+
+    if cookie_saved:
+        st.session_state["prefs_persistence_notice"] = (
+            "Browser-local preference storage is unavailable. Using cookie backup preferences."
+        )
+        return True
+
+    st.session_state["prefs_persistence_notice"] = (
+        "Browser-local preference storage is unavailable. Using session-only preferences."
+    )
+    return False
 
 
 def build_settings_export_payload(prefs: dict[str, Any]) -> dict[str, Any]:
@@ -2172,6 +2244,10 @@ def render_sidebar(catalog_meta: dict[str, Any], prefs: dict[str, Any], browser_
         if persistence_notice:
             st.warning(persistence_notice)
 
+        cookie_backup_notice = get_cookie_backup_notice()
+        if cookie_backup_notice:
+            st.caption(cookie_backup_notice)
+
         location_notice = st.session_state.pop("location_notice", "")
         if location_notice:
             st.info(location_notice)
@@ -2553,17 +2629,32 @@ def render_detail_panel(
 
 def main() -> None:
     st_autorefresh(interval=60_000, key="altaz_refresh")
+    set_cookie_backup_runtime_enabled(ENABLE_COOKIE_BACKUP)
+    bootstrap_cookie_backup()
 
     if "prefs_bootstrap_runs" not in st.session_state:
         st.session_state["prefs_bootstrap_runs"] = 0
+    if "prefs_bootstrapped" not in st.session_state:
+        st.session_state["prefs_bootstrapped"] = False
     if "prefs" not in st.session_state:
         st.session_state["prefs"] = default_preferences()
 
-    if int(st.session_state.get("prefs_bootstrap_runs", 0)) < 2:
-        st.session_state["prefs"] = load_preferences()
-        st.session_state["prefs_bootstrap_runs"] = int(st.session_state.get("prefs_bootstrap_runs", 0)) + 1
-        if int(st.session_state.get("prefs_bootstrap_runs", 0)) < 2:
-            st.rerun()
+    if not bool(st.session_state.get("prefs_bootstrapped", False)):
+        runs = int(st.session_state.get("prefs_bootstrap_runs", 0))
+        loaded_prefs, retry_needed = load_preferences()
+        st.session_state["prefs"] = loaded_prefs
+        runs += 1
+        st.session_state["prefs_bootstrap_runs"] = runs
+
+        if retry_needed and runs < PREFS_BOOTSTRAP_MAX_RUNS:
+            st_autorefresh(
+                interval=PREFS_BOOTSTRAP_RETRY_INTERVAL_MS,
+                limit=1,
+                key=f"prefs_bootstrap_wait_{runs}",
+            )
+            st.stop()
+
+        st.session_state["prefs_bootstrapped"] = True
 
     prefs = ensure_preferences_shape(st.session_state["prefs"])
     st.session_state["prefs"] = prefs

--- a/prefs_cookie_backup.py
+++ b/prefs_cookie_backup.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+import streamlit as st
+
+try:
+    from extra_streamlit_components import CookieManager
+except Exception:
+    CookieManager = None
+
+COOKIE_BACKUP_KEY = "dso_explorer_prefs_backup_v1"
+COOKIE_BACKUP_TTL_DAYS = 365
+COOKIE_BACKUP_MAX_VALUE_CHARS = 3500
+COOKIE_BACKUP_DISABLE_AFTER_MISSES = 2
+
+_STATE_ENABLED = "_prefs_cookie_backup_enabled"
+_STATE_RUNTIME_ENABLED = "_prefs_cookie_backup_runtime_enabled"
+_STATE_MANAGER = "_prefs_cookie_backup_manager"
+_STATE_PENDING_HASH = "_prefs_cookie_backup_pending_hash"
+_STATE_UNOBSERVED_MISSES = "_prefs_cookie_backup_unobserved_misses"
+_STATE_NOTICE = "prefs_cookie_backup_notice"
+
+
+def set_cookie_backup_runtime_enabled(enabled: bool) -> None:
+    st.session_state[_STATE_RUNTIME_ENABLED] = bool(enabled)
+    if enabled:
+        return
+
+    st.session_state[_STATE_ENABLED] = False
+    st.session_state.pop(_STATE_MANAGER, None)
+    st.session_state.pop(_STATE_PENDING_HASH, None)
+    st.session_state.pop(_STATE_UNOBSERVED_MISSES, None)
+    st.session_state.pop(_STATE_NOTICE, None)
+
+
+def is_cookie_backup_enabled() -> bool:
+    if not bool(st.session_state.get(_STATE_RUNTIME_ENABLED, True)):
+        return False
+    if CookieManager is None:
+        return False
+    return bool(st.session_state.get(_STATE_ENABLED, True))
+
+
+def get_cookie_backup_notice() -> str:
+    if not bool(st.session_state.get(_STATE_RUNTIME_ENABLED, True)):
+        return ""
+    notice = st.session_state.get(_STATE_NOTICE, "")
+    return str(notice).strip() if isinstance(notice, str) else ""
+
+
+def bootstrap_cookie_backup() -> None:
+    if not is_cookie_backup_enabled():
+        return
+    _ = _get_cookie_manager()
+
+
+def read_preferences_cookie_backup() -> str:
+    if not is_cookie_backup_enabled():
+        return ""
+
+    manager = _get_cookie_manager()
+    if manager is None:
+        return ""
+
+    try:
+        all_cookies = manager.get_all(key="browser_prefs_cookie_get_all")
+        value = all_cookies.get(COOKIE_BACKUP_KEY, "") if isinstance(all_cookies, dict) else ""
+        _track_pending_write_visibility(value)
+        return str(value).strip() if isinstance(value, str) else ""
+    except Exception:
+        return ""
+
+
+def write_preferences_cookie_backup(encoded_value: str) -> bool:
+    if not is_cookie_backup_enabled():
+        return False
+
+    payload_hash = hashlib.sha1(encoded_value.encode("ascii")).hexdigest()[:12]
+    try:
+        if len(encoded_value) > COOKIE_BACKUP_MAX_VALUE_CHARS:
+            _set_cookie_value("", -1, component_key=f"browser_prefs_cookie_clear_{payload_hash}")
+            st.session_state[_STATE_NOTICE] = (
+                "Cookie backup skipped: preferences are too large for a browser cookie."
+            )
+            return False
+
+        cookie_saved = _set_cookie_value(
+            encoded_value,
+            COOKIE_BACKUP_TTL_DAYS,
+            component_key=f"browser_prefs_cookie_write_{payload_hash}",
+        )
+        if not cookie_saved:
+            _disable_cookie_backup("Cookie backup is unavailable in this browser session. Using local storage only.")
+            return False
+
+        st.session_state.pop(_STATE_NOTICE, None)
+        return True
+    except Exception:
+        _disable_cookie_backup("Cookie backup is unavailable in this browser session. Using local storage only.")
+        return False
+
+
+def _disable_cookie_backup(notice: str) -> None:
+    st.session_state[_STATE_ENABLED] = False
+    st.session_state.pop(_STATE_PENDING_HASH, None)
+    st.session_state.pop(_STATE_UNOBSERVED_MISSES, None)
+    st.session_state[_STATE_NOTICE] = notice
+
+
+def _get_cookie_manager() -> Any | None:
+    manager = st.session_state.get(_STATE_MANAGER)
+    if CookieManager is not None and isinstance(manager, CookieManager):
+        return manager
+
+    try:
+        manager = CookieManager(key="browser_cookie_manager_init")
+        st.session_state[_STATE_MANAGER] = manager
+        return manager
+    except Exception:
+        st.session_state[_STATE_MANAGER] = None
+        return None
+
+
+def _track_pending_write_visibility(observed_value: Any) -> None:
+    pending_hash = str(st.session_state.get(_STATE_PENDING_HASH, "")).strip()
+    if not pending_hash:
+        return
+
+    observed_hash = (
+        hashlib.sha1(observed_value.encode("ascii")).hexdigest()[:12]
+        if isinstance(observed_value, str) and observed_value
+        else ""
+    )
+    if observed_hash and observed_hash == pending_hash:
+        st.session_state.pop(_STATE_PENDING_HASH, None)
+        st.session_state.pop(_STATE_UNOBSERVED_MISSES, None)
+        return
+
+    misses = int(st.session_state.get(_STATE_UNOBSERVED_MISSES, 0)) + 1
+    st.session_state[_STATE_UNOBSERVED_MISSES] = misses
+    if misses >= COOKIE_BACKUP_DISABLE_AFTER_MISSES:
+        _disable_cookie_backup("Cookie backup appears blocked in this browser session. Using local storage only.")
+
+
+def _set_cookie_value(value: str, duration_days: int, component_key: str) -> bool:
+    manager = _get_cookie_manager()
+    if manager is None:
+        return False
+
+    try:
+        if duration_days < 0:
+            manager.delete(COOKIE_BACKUP_KEY, key=f"{component_key}_delete")
+            st.session_state.pop(_STATE_PENDING_HASH, None)
+            return True
+
+        ttl_days = max(1, int(duration_days))
+        max_age_seconds = int(ttl_days * 24 * 60 * 60)
+        manager.set(
+            cookie=COOKIE_BACKUP_KEY,
+            val=value,
+            key=component_key,
+            path="/",
+            max_age=max_age_seconds,
+            same_site="lax",
+        )
+        payload_hash = hashlib.sha1(value.encode("ascii")).hexdigest()[:12]
+        st.session_state[_STATE_PENDING_HASH] = payload_hash
+        return True
+    except Exception:
+        return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ geopy>=2.4
 timezonefinder>=6.5
 requests>=2.31
 streamlit-js-eval>=1.0.0
+extra-streamlit-components>=0.1.81


### PR DESCRIPTION
## Summary
- increase radial Sky Position plot size from 330 to 660 for better readability
- add keyword handling so searching `favorites` (case-insensitive; also `favorite`) returns the user's favorites list
- add browser preference persistence fallback: write to localStorage first, then cookie backup
- add fallback load path: if localStorage is empty/unavailable, read cookie backup and rehydrate localStorage
- isolate cookie backup logic into `prefs_cookie_backup.py` and add single feature toggle `ENABLE_COOKIE_BACKUP`

## Details
- Added resilient preference bootstrap retries in `main()` to handle initial component timing races.
- Cookie backup has a circuit-breaker: if writes are repeatedly unobserved, backup is disabled for the session.
- Added `extra-streamlit-components` dependency for cookie helper support.
- Sidebar now shows persistence notices when local-only or session-only fallback modes are active.

## Notes
- Local `README.md` draft changes were intentionally not included in this commit.
