### PR TITLE
Refactor catalog layer: service API, loader modes, and validation

### DIFF
--- a/catalog_service.py
+++ b/catalog_service.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from catalog_ingestion import OPTIONAL_COLUMNS, REQUIRED_COLUMNS, load_unified_catalog
+
+CATALOG_MODE_LEGACY = "legacy"
+CATALOG_MODE_CURATED_PARQUET = "curated_parquet"
+
+SEARCH_INDEX_COLUMNS = ["primary_id_norm", "aliases_norm", "search_blob_norm"]
+_VALID_CATALOG_MODES = {CATALOG_MODE_LEGACY, CATALOG_MODE_CURATED_PARQUET}
+
+
+def normalize_text(value: str | None) -> str:
+    if value is None:
+        return ""
+    return re.sub(r"[^a-z0-9]", "", value.lower())
+
+
+def canonicalize_designation(query: str) -> str:
+    compact = normalize_text(query)
+
+    match = re.match(r"^(messier|m)(\d+)$", compact)
+    if match:
+        return f"M{int(match.group(2))}"
+
+    match = re.match(r"^(ngc)(\d+)$", compact)
+    if match:
+        return f"NGC {int(match.group(2))}"
+
+    match = re.match(r"^(ic)(\d+)$", compact)
+    if match:
+        return f"IC {int(match.group(2))}"
+
+    match = re.match(r"^(sh2|sharpless)(\d+)$", compact)
+    if match:
+        return f"Sh2-{int(match.group(2))}"
+
+    return query.strip()
+
+
+def list_catalog_filters(catalog: pd.DataFrame) -> dict[str, list[str]]:
+    def _sorted_unique(column: str) -> list[str]:
+        if column not in catalog.columns:
+            return []
+        values = (
+            catalog[column]
+            .fillna("")
+            .astype(str)
+            .str.strip()
+        )
+        values = values[values != ""]
+        return sorted(values.unique().tolist())
+
+    return {
+        "catalogs": _sorted_unique("catalog"),
+        "object_types": _sorted_unique("object_type"),
+        "constellations": _sorted_unique("constellation"),
+    }
+
+
+def get_object_by_id(catalog: pd.DataFrame, primary_id: str | None) -> pd.Series | None:
+    target_id = str(primary_id or "").strip()
+    if not target_id or "primary_id" not in catalog.columns:
+        return None
+
+    matches = catalog[catalog["primary_id"] == target_id]
+    if matches.empty:
+        return None
+    return matches.iloc[0]
+
+
+def search_catalog(catalog: pd.DataFrame, query: str) -> pd.DataFrame:
+    if not query.strip():
+        return catalog.copy()
+
+    indexed = _ensure_search_index(catalog)
+    canonical = canonicalize_designation(query)
+    query_norm = normalize_text(query)
+    canonical_norm = normalize_text(canonical)
+
+    exact_mask = (indexed["primary_id_norm"] == query_norm) | (indexed["primary_id_norm"] == canonical_norm)
+    alias_exact = indexed["aliases_norm"].str.contains(query_norm, regex=False) | indexed["aliases_norm"].str.contains(
+        canonical_norm,
+        regex=False,
+    )
+    partial_mask = indexed["search_blob_norm"].str.contains(query_norm, regex=False)
+
+    results = indexed[exact_mask | alias_exact | partial_mask].copy()
+    results["_rank"] = np.where(exact_mask.loc[results.index] | alias_exact.loc[results.index], 0, 1)
+    results = results.sort_values(by=["_rank", "catalog", "primary_id"], ascending=[True, True, True])
+    return results.drop(columns=["_rank"])
+
+
+def load_catalog_data(
+    *,
+    seed_path: Path,
+    cache_path: Path,
+    metadata_path: Path,
+    force_refresh: bool = False,
+    mode: str = CATALOG_MODE_LEGACY,
+    curated_path: Path | None = None,
+) -> tuple[pd.DataFrame, dict[str, Any]]:
+    requested_mode = str(mode).strip().lower()
+    notes: list[str] = []
+
+    if requested_mode not in _VALID_CATALOG_MODES:
+        notes.append(f"Unknown catalog mode '{requested_mode}', falling back to '{CATALOG_MODE_LEGACY}'.")
+        requested_mode = CATALOG_MODE_LEGACY
+
+    if requested_mode == CATALOG_MODE_CURATED_PARQUET:
+        curated_catalog_path = curated_path or cache_path
+        try:
+            curated_frame = pd.read_parquet(curated_catalog_path)
+            indexed_curated = _build_search_index(curated_frame)
+            validation = validate_catalog(indexed_curated)
+            if validation["missing_required_columns"]:
+                missing = ", ".join(validation["missing_required_columns"])
+                raise ValueError(f"missing required columns: {missing}")
+            if validation["duplicate_primary_id_count"] > 0:
+                raise ValueError(f"duplicate primary_id rows: {validation['duplicate_primary_id_count']}")
+            if validation["blank_primary_id_count"] > 0:
+                raise ValueError(f"blank primary_id rows: {validation['blank_primary_id_count']}")
+            if validation["row_count"] <= 0:
+                raise ValueError("catalog has zero rows")
+
+            catalog_counts = (
+                indexed_curated["catalog"].value_counts().to_dict()
+                if "catalog" in indexed_curated.columns
+                else {}
+            )
+            metadata = {
+                "load_mode": CATALOG_MODE_CURATED_PARQUET,
+                "source": str(curated_catalog_path),
+                "cache": str(curated_catalog_path),
+                "row_count": int(len(indexed_curated)),
+                "catalog_counts": catalog_counts,
+                "validation": validation,
+                "feature_mode_requested": mode,
+                "feature_mode_active": CATALOG_MODE_CURATED_PARQUET,
+                "filters": list_catalog_filters(indexed_curated),
+            }
+            return indexed_curated, metadata
+        except Exception as error:
+            notes.append(
+                "Curated catalog mode fallback to legacy: "
+                f"{error.__class__.__name__}: {str(error).strip() or 'unknown error'}"
+            )
+
+    frame, metadata = load_unified_catalog(
+        seed_path=seed_path,
+        cache_path=cache_path,
+        metadata_path=metadata_path,
+        force_refresh=force_refresh,
+    )
+    indexed = _build_search_index(frame)
+    validation = validate_catalog(indexed)
+
+    meta = dict(metadata or {})
+    existing_notes = meta.get("notes", [])
+    merged_notes: list[str] = []
+    if isinstance(existing_notes, list):
+        merged_notes.extend(str(note) for note in existing_notes if str(note).strip())
+    elif isinstance(existing_notes, str) and existing_notes.strip():
+        merged_notes.append(existing_notes.strip())
+    merged_notes.extend(notes)
+    if merged_notes:
+        meta["notes"] = merged_notes
+
+    if "row_count" not in meta:
+        meta["row_count"] = int(len(indexed))
+    if "catalog_counts" not in meta and "catalog" in indexed.columns:
+        meta["catalog_counts"] = indexed["catalog"].value_counts().to_dict()
+
+    meta["validation"] = validation
+    meta["feature_mode_requested"] = mode
+    meta["feature_mode_active"] = CATALOG_MODE_LEGACY
+    meta["filters"] = list_catalog_filters(indexed)
+
+    return indexed, meta
+
+
+def validate_catalog(catalog: pd.DataFrame) -> dict[str, Any]:
+    required_columns = list(REQUIRED_COLUMNS)
+    missing_required_columns = [column for column in required_columns if column not in catalog.columns]
+
+    row_count = int(len(catalog))
+    if "primary_id" in catalog.columns:
+        primary_ids = catalog["primary_id"].fillna("").astype(str).str.strip()
+        blank_primary_id_count = int((primary_ids == "").sum())
+        unique_primary_id_count = int(primary_ids[primary_ids != ""].nunique())
+        duplicate_primary_id_count = int(primary_ids[primary_ids != ""].duplicated().sum())
+    else:
+        blank_primary_id_count = row_count
+        unique_primary_id_count = 0
+        duplicate_primary_id_count = 0
+
+    warnings: list[str] = []
+    if missing_required_columns:
+        warnings.append(f"Missing required columns: {', '.join(missing_required_columns)}.")
+    if row_count == 0:
+        warnings.append("Catalog contains zero rows.")
+    if blank_primary_id_count > 0:
+        warnings.append(f"Catalog contains {blank_primary_id_count} blank primary_id values.")
+    if duplicate_primary_id_count > 0:
+        warnings.append(f"Catalog contains {duplicate_primary_id_count} duplicate primary_id values.")
+
+    return {
+        "required_columns": required_columns,
+        "optional_columns": list(OPTIONAL_COLUMNS),
+        "row_count": row_count,
+        "unique_primary_id_count": unique_primary_id_count,
+        "blank_primary_id_count": blank_primary_id_count,
+        "duplicate_primary_id_count": duplicate_primary_id_count,
+        "missing_required_columns": missing_required_columns,
+        "warnings": warnings,
+    }
+
+
+def _ensure_search_index(catalog: pd.DataFrame) -> pd.DataFrame:
+    if all(column in catalog.columns for column in SEARCH_INDEX_COLUMNS):
+        return catalog
+    return _build_search_index(catalog)
+
+
+def _build_search_index(frame: pd.DataFrame) -> pd.DataFrame:
+    indexed = frame.copy()
+    for column in ["common_name", "object_type", "constellation", "aliases", "catalog"]:
+        if column in indexed.columns:
+            indexed[column] = indexed[column].fillna("")
+
+    indexed["primary_id_norm"] = indexed["primary_id"].map(normalize_text)
+    indexed["aliases_norm"] = indexed["aliases"].map(normalize_text)
+    indexed["search_blob_norm"] = (
+        indexed["primary_id"].fillna("")
+        + " "
+        + indexed["common_name"].fillna("")
+        + " "
+        + indexed["aliases"].fillna("")
+        + " "
+        + indexed["catalog"].fillna("")
+    ).map(normalize_text)
+
+    return indexed


### PR DESCRIPTION
## Summary
- extract catalog loading/search/lookup logic from `app.py` into a dedicated `catalog_service.py`
- define a stable catalog service interface for upcoming overhaul work
- add loader-mode feature flag support (`legacy` vs `curated_parquet`) with safe fallback to legacy
- add startup catalog validation (schema presence, row count, key uniqueness) and surface results in Settings

## Catalog Service API
- `load_catalog_data(...)`
- `search_catalog(...)`
- `get_object_by_id(...)`
- `list_catalog_filters(...)`

## Rollout Safety
- `CATALOG_LOADER_MODE` controls active mode in `app.py`
- curated mode validates input and falls back to legacy on load/validation errors
- metadata now includes requested/active mode, filters summary, and validation details

## Validation
- `PYTHONPYCACHEPREFIX=.pycache_tmp ./.venv/bin/python -m py_compile app.py catalog_service.py prefs_cookie_backup.py`

## Notes
- intentionally leaves unrelated local files untouched (`README.md`, generated CSV exports)
