### PR TITLE
Add Wikipedia enrichment workflow and review app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,6 @@ venv/
 
 # Local persisted prototype state
 .state/preferences.json
-data/dso_catalog_cache.parquet
-data/dso_catalog_cache_meta.json
 
 # OS/editor
 .DS_Store

--- a/CATALOG_DATAFLOW.md
+++ b/CATALOG_DATAFLOW.md
@@ -1,0 +1,106 @@
+# Catalog Dataflow (Disk vs Network)
+
+This document describes how catalog loading/build works in this repo and when it uses only local files versus external network calls.
+
+## 1) App Catalog Load Dataflow
+
+```mermaid
+flowchart TD
+    A["App startup or refresh\nCatalog load"] --> B{Loader mode}
+
+    B -->|curated_parquet| C[Read data/dso_catalog_curated.parquet]
+    C --> COK{Valid parquet + schema?}
+    COK -->|yes| CEND[[Return catalog\nDisk-only]]
+    COK -->|no| L
+
+    B -->|legacy default| L[Legacy unified loader]
+
+    L --> D{Can reuse cache?\nall true:\n- not force_refresh\n- cache file exists and is readable}
+    D -->|yes| E[Read data/dso_catalog_cache.parquet + metadata]
+    E --> EEND[[Return catalog\nDisk-only]]
+
+    D -->|no| F{Does data/DSO_CATALOG_ENRICHED.CSV exist?}
+
+    F -->|yes| G[Read enriched CSV]
+    G --> H{Old parquet exists?}
+    H -->|yes| I[Read old parquet and append cache-only IDs\n(no overwrite of enriched IDs)]
+    H -->|no| J[Use enriched rows as base]
+    I --> K
+    J --> K
+
+    F -->|no| O[Fetch OpenNGC CSV]
+    O --> P{OpenNGC success?}
+    P -->|yes| Q[Use OpenNGC rows]
+    P -->|no| R[Read data/dso_catalog_seed.csv fallback]
+    Q --> K
+    R --> K
+
+    K[Attempt SIMBAD named-object ingest\n(merge + M/NGC enrichment)] --> S[Normalize + type mapping/grouping]
+    S --> T[Write data/dso_catalog_cache.parquet]
+    T --> U[Write data/dso_catalog_cache_meta.json]
+    U --> V[[Return rebuilt catalog]]
+
+    classDef disk fill:#e7f5ff,stroke:#1c7ed6,stroke-width:1px;
+    classDef net fill:#fff4e6,stroke:#d9480f,stroke-width:1px;
+
+    class C,E,G,I,J,R,T,U disk;
+    class O,K net;
+```
+
+## 2) Exactly When We Are Disk-Only
+
+Disk-only catalog loads happen when either:
+
+- `curated_parquet` mode succeeds reading `data/dso_catalog_curated.parquet`, or
+- `legacy` mode decides cache is reusable and returns `data/dso_catalog_cache.parquet`.
+
+In both cases, no catalog-source network fetches are attempted.
+
+Deployment intent:
+
+- `data/dso_catalog_cache.parquet` is treated as a shipped app artifact.
+- Refresh/replacement is on-demand (manual refresh/CLI), not time-based.
+
+## 3) Exactly When Network Calls Happen
+
+Network calls happen when a rebuild is needed (cache not reusable or forced refresh):
+
+- OpenNGC HTTP fetch is attempted only when enriched CSV path is unavailable/disabled/fails.
+- SIMBAD TAP fetch is attempted during rebuild (after base frame selection).
+
+Typical triggers for rebuild:
+
+- Settings button `Refresh catalog cache` (sets `force_refresh=True`).
+- Running `python scripts/ingest_catalog.py` (always `force_refresh=True`).
+- Cache file is missing.
+- Cache file exists but cannot be read/normalized.
+
+## 4) Wikipedia Enrichment Script (from cached parquet)
+
+```mermaid
+flowchart TD
+    W0[Wikipedia enrichment script] --> W1[Read catalog parquet\ndefault data/dso_catalog_cache.parquet]
+    W1 --> W2[Filter target rows by catalog/group]
+    W2 --> W3[Load prior output JSON if resume enabled]
+    W3 --> W4[Load API cache JSON\ndata/wikipedia_api_cache.json]
+    W4 --> W5{Per target: resume/cache hit?}
+    W5 -->|yes| W6[Reuse local result\nDisk-only]
+    W5 -->|no| W7[Call Wikipedia APIs]
+    W6 --> W8[Write output JSON]
+    W7 --> W8
+    W8 --> W9[Flush updated API cache JSON]
+
+    classDef disk fill:#e7f5ff,stroke:#1c7ed6,stroke-width:1px;
+    classDef net fill:#fff4e6,stroke:#d9480f,stroke-width:1px;
+
+    class W1,W2,W3,W4,W6,W8,W9 disk;
+    class W7 net;
+```
+
+## 5) Key Files
+
+- Loader entry: `app.py`
+- Loader orchestration: `catalog_service.py`
+- Ingest/cache logic: `catalog_ingestion.py`
+- Force-rebuild CLI: `scripts/ingest_catalog.py`
+- Wikipedia enrichment (reads parquet, optionally calls web): `scripts/build_wikipedia_catalog_enrichment.py`

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Notes:
 
 - Catalog ingest loads full OpenNGC data and augments it with SIMBAD (`NAME` objects are retained, with unmatched rows kept as `SIMBAD` catalog entries).
 - If live ingest fails, the app falls back to the local seed dataset.
-- Use the sidebar `Refresh catalog cache` button to force a re-ingest.
+- Catalog cache is reused by default and refreshed only on demand (sidebar `Refresh catalog cache` or `python scripts/ingest_catalog.py`).
 - Weather and image lookups fail gracefully without breaking plots.

--- a/TODO.md
+++ b/TODO.md
@@ -4,15 +4,15 @@
 - [x] Define unified catalog schema and normalize seed data.
 - [x] Add disk cache (`parquet`) + metadata for ingest runs.
 - [x] Add in-app control to refresh catalog ingestion cache.
-- [ ] Expand seed dataset toward full catalog coverage for M/NGC/IC/SH2.
+- [x] Expand seed dataset toward full catalog coverage for M/NGC/IC/SH2.
 - [ ] Add source-specific ingest adapters (one module per catalog source).
 - [ ] Add ingest validation checks (required fields, RA/Dec ranges, duplicate IDs).
-- [ ] Add ingest tests and a CLI entry point for batch refresh.
+- [x] Add ingest tests and a CLI entry point for batch refresh.
 
 ## Phase 2: Location + Sky Semantics
 - [x] Manual geocoding (ZIP/place) with fallback to last valid location.
 - [x] Browser geolocation permission flow (navigator API via Streamlit component).
-- [ ] Improve reverse-geocode labels (city/state/country quality checks).
+- [x] Improve reverse-geocode labels (city/state/country quality checks).
 - [ ] Add explicit permission-state messaging and retry flow.
 - [ ] Add location source badges (`default`, `manual`, `browser`, `ip`).
 
@@ -30,7 +30,7 @@
 - [ ] Add cache TTL controls per external source.
 
 ## Phase 5: UI/UX Polish (Deferred by request)
-- [ ] Refine responsive desktop/tablet split behavior.
+- [x] Refine responsive desktop/tablet split behavior.
 - [ ] Implement phone-style detail bottom sheet interactions.
 - [ ] Improve typography, spacing, and hierarchy for scanability.
 - [ ] Add onboarding guidance for first-time users.
@@ -39,3 +39,26 @@
 - [ ] Finalize private GitHub repo settings and branch protections.
 - [ ] Add CI checks (lint + type checks + smoke tests).
 - [ ] Add deployment target (Streamlit Community Cloud or container).
+
+
+
+# longer term planning horizon
+
+## unpriorized backlog
+- [ ] add resilience for missing weather data
+- [ ] add lunar interference model
+- [ ] add the notion of "sweet spot" (visible, unobstructed, not in danger zone of mounts, no lunar interference)
+- [ ] disconnect night sky preview from "pinning", introduce more general list concept
+- [ ] look at things like https://en.wikipedia.org/wiki/Lists_of_nebulae for catalog enrichment
+- [ ] integrate barnard objects, caldwell objects
+  
+## launch Phase
+- [ ] build github pages based website
+- [ ] create product usage documentation- wiki?
+- [ ] create hero images of app 
+- [ ] integrate some sort of uservoice system for bug tracking
+
+
+## refactoring plans
+- [ ] pull weather service out into its own folder
+- [ ] break up main UI (search, forecast, details, night sky preview) into files/folders

--- a/data/object_type_groups.csv
+++ b/data/object_type_groups.csv
@@ -26,6 +26,7 @@ Bright Nebula,Supernova_candidate,Supernova_candidate
 Bright Nebula,SNRemnant,SNRemnant
 Bright Nebula,SNR,SNR
 Bright Nebula,HII,HII
+Bright Nebula,HIIReg,HIIReg
 Bright Nebula,HIshell,HIshell
 Bright Nebula,OH/IR*,OH/IR*
 Dark Nebula,reflection_nebula,reflection_nebula

--- a/data/wikipedia_catalog_enrichment_review.html
+++ b/data/wikipedia_catalog_enrichment_review.html
@@ -1,0 +1,900 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Wikipedia Enrichment Review</title>
+  <style>
+    :root {
+      --bg: #f4f5f7;
+      --surface: #ffffff;
+      --text: #111827;
+      --muted: #6b7280;
+      --line: #d1d5db;
+      --accent: #0f766e;
+      --good: #166534;
+      --warn: #9a3412;
+      --reject: #7f1d1d;
+      --shadow: 0 6px 22px rgba(17,24,39,0.08);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+      color: var(--text);
+      background: radial-gradient(circle at top right, #e6f4f1 0%, var(--bg) 40%);
+    }
+    .wrap {
+      max-width: none;
+      margin: 0 auto;
+      padding: 20px 18px 28px;
+    }
+    .hero {
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      box-shadow: var(--shadow);
+      padding: 18px;
+      margin-bottom: 14px;
+    }
+    h1 {
+      margin: 0 0 6px;
+      font-size: 1.35rem;
+      letter-spacing: 0.01em;
+    }
+    .meta {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+    .stats {
+      margin-top: 12px;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 8px;
+    }
+    .stat-btn {
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      padding: 9px 10px;
+      background: #f8fafc;
+      font-size: 0.85rem;
+      cursor: pointer;
+      text-align: left;
+      color: var(--text);
+    }
+    .stat-btn.active {
+      border-color: #0f766e;
+      box-shadow: inset 0 0 0 1px #0f766e;
+      background: #ecfeff;
+    }
+    .controls {
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      box-shadow: var(--shadow);
+      padding: 12px;
+      display: grid;
+      grid-template-columns: 1.5fr 0.85fr 0.9fr 0.9fr 0.95fr 1fr 0.7fr auto auto;
+      gap: 8px;
+      margin-bottom: 14px;
+      align-items: center;
+    }
+    .controls input,
+    .controls select,
+    .controls button {
+      width: 100%;
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      padding: 8px 10px;
+      background: #fff;
+      font-size: 0.9rem;
+    }
+    .controls button {
+      background: #f8fafc;
+      cursor: pointer;
+    }
+    .controls .check {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 0.88rem;
+      color: var(--muted);
+      white-space: nowrap;
+    }
+    .bulk-controls {
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      box-shadow: var(--shadow);
+      padding: 10px 12px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      align-items: center;
+      margin-bottom: 14px;
+    }
+    .selection-summary {
+      color: var(--muted);
+      font-size: 0.88rem;
+      margin-right: 4px;
+    }
+    .bulk-controls button {
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      padding: 8px 10px;
+      background: #f8fafc;
+      font-size: 0.9rem;
+      cursor: pointer;
+    }
+    .bulk-controls button:disabled {
+      opacity: 0.45;
+      cursor: default;
+    }
+    .cards {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(290px, 1fr));
+      gap: 12px;
+    }
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      box-shadow: var(--shadow);
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      min-height: 390px;
+    }
+    .img-wrap {
+      width: 100%;
+      height: 190px;
+      background: #eef2f7;
+      border-bottom: 1px solid var(--line);
+      display: grid;
+      place-items: center;
+      color: var(--muted);
+      font-size: 0.85rem;
+    }
+    .img-wrap img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+    .body {
+      padding: 10px 12px 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 7px;
+    }
+    .title {
+      margin: 0;
+      font-size: 1rem;
+      line-height: 1.2;
+    }
+    .subtitle {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.82rem;
+      line-height: 1.35;
+    }
+    .status {
+      display: inline-block;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      font-size: 0.74rem;
+      padding: 3px 8px;
+      width: fit-content;
+      background: #f8fafc;
+    }
+    .status.matched {
+      border-color: #86efac;
+      background: #f0fdf4;
+      color: var(--good);
+    }
+    .status.no_match {
+      border-color: #fdba74;
+      background: #fff7ed;
+      color: var(--warn);
+    }
+    .status.rejected {
+      border-color: #fca5a5;
+      background: #fef2f2;
+      color: var(--reject);
+    }
+    .desc {
+      margin: 0;
+      font-size: 0.9rem;
+      line-height: 1.45;
+    }
+    .meta-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin-top: auto;
+    }
+    .chip {
+      border: 1px solid var(--line);
+      background: #f8fafc;
+      border-radius: 999px;
+      padding: 3px 8px;
+      font-size: 0.73rem;
+      color: #334155;
+    }
+    .link {
+      text-decoration: none;
+      color: var(--accent);
+      font-size: 0.82rem;
+    }
+    .action-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 2px;
+    }
+    .action-btn {
+      border: 1px solid var(--line);
+      background: #fff;
+      border-radius: 9px;
+      padding: 5px 8px;
+      font-size: 0.78rem;
+      cursor: pointer;
+    }
+    .action-btn.reject-btn {
+      border-color: #fecaca;
+      color: var(--reject);
+      background: #fff7f7;
+    }
+    .action-btn.reject-btn.active {
+      border-color: #ef4444;
+      color: #fff;
+      background: #b91c1c;
+    }
+    .select-item {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 0.78rem;
+      color: var(--muted);
+      border: 1px solid var(--line);
+      background: #fff;
+      border-radius: 9px;
+      padding: 5px 8px;
+      user-select: none;
+      cursor: pointer;
+    }
+    .select-item input {
+      margin: 0;
+    }
+    .pager {
+      margin: 14px 0 2px;
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      justify-content: center;
+    }
+    .pager button {
+      border: 1px solid var(--line);
+      background: #fff;
+      border-radius: 10px;
+      padding: 8px 10px;
+      cursor: pointer;
+    }
+    .pager button:disabled {
+      opacity: 0.45;
+      cursor: default;
+    }
+    .empty {
+      text-align: center;
+      color: var(--muted);
+      padding: 24px 0;
+    }
+    .empty.error {
+      color: var(--reject);
+      background: #fff5f5;
+      border: 1px solid #fecaca;
+      border-radius: 10px;
+      padding: 12px;
+      margin-bottom: 10px;
+    }
+    @media (max-width: 1100px) {
+      .controls {
+        grid-template-columns: 1fr 1fr 1fr 1fr;
+      }
+    }
+    @media (max-width: 680px) {
+      .controls {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <section class="hero">
+      <h1>Wikipedia Catalog Enrichment Review</h1>
+      <p class="meta" id="metaLine"></p>
+      <div class="stats" id="topStats"></div>
+    </section>
+
+    <section class="controls">
+      <input id="search" type="search" placeholder="Search title, primary ID, description, designations..." />
+      <select id="statusFilter">
+        <option value="all">All statuses</option>
+        <option value="matched">Matched only</option>
+        <option value="no_match">No match only</option>
+        <option value="rejected">Rejected only</option>
+      </select>
+      <select id="catalogFilter">
+        <option value="all">All catalogs</option>
+      </select>
+      <select id="groupFilter">
+        <option value="all">All object groups</option>
+      </select>
+      <select id="descFilter">
+        <option value="all">All descriptions</option>
+        <option value="with">With description</option>
+        <option value="without">No description only</option>
+      </select>
+      <select id="sortBy">
+        <option value="score_desc">Sort: score high to low</option>
+        <option value="score_asc">Sort: score low to high</option>
+        <option value="title_asc">Sort: title A-Z</option>
+        <option value="primary_asc">Sort: primary ID A-Z</option>
+      </select>
+      <label class="check"><input id="imagesOnly" type="checkbox" /> Image only</label>
+      <select id="pageSize">
+        <option value="24">24 / page</option>
+        <option value="48" selected>48 / page</option>
+        <option value="96">96 / page</option>
+        <option value="200">200 / page</option>
+      </select>
+      <button id="exportRejectedBtn" type="button">Export rejected</button>
+      <button id="clearRejectedBtn" type="button">Clear rejected</button>
+    </section>
+
+    <section class="bulk-controls">
+      <span class="selection-summary" id="selectionSummary">0 selected</span>
+      <button id="selectPageBtn" type="button">Select all on page</button>
+      <button id="clearSelectedBtn" type="button">Clear selected</button>
+      <button id="rejectSelectedBtn" type="button">Reject selected</button>
+      <button id="unrejectSelectedBtn" type="button">Unreject selected</button>
+    </section>
+
+    <div class="empty" id="resultSummary"></div>
+    <section class="cards" id="cards"></section>
+    <div class="pager">
+      <button id="prevBtn">Prev</button>
+      <span id="pageLabel"></span>
+      <button id="nextBtn">Next</button>
+    </div>
+  </div>
+
+  <script>
+    const jsonPath = "wikipedia_catalog_enrichment.json";
+    const builtAt = "2026-02-14T23:29:50+00:00";
+    const REJECT_KEY = "wikipedia_enrichment_rejected_primary_ids_v1";
+
+    let payload = {};
+    let targets = [];
+    let generatedAt = "";
+    let selection = {};
+    let stats = {};
+
+    let currentPage = 1;
+    let metricFilter = "all";
+    let currentPageRows = [];
+
+    const searchEl = document.getElementById("search");
+    const statusEl = document.getElementById("statusFilter");
+    const catalogEl = document.getElementById("catalogFilter");
+    const groupEl = document.getElementById("groupFilter");
+    const descFilterEl = document.getElementById("descFilter");
+    const sortEl = document.getElementById("sortBy");
+    const imageOnlyEl = document.getElementById("imagesOnly");
+    const pageSizeEl = document.getElementById("pageSize");
+    const cardsEl = document.getElementById("cards");
+    const resultSummaryEl = document.getElementById("resultSummary");
+    const pageLabelEl = document.getElementById("pageLabel");
+    const prevBtnEl = document.getElementById("prevBtn");
+    const nextBtnEl = document.getElementById("nextBtn");
+    const topStatsEl = document.getElementById("topStats");
+    const exportRejectedBtnEl = document.getElementById("exportRejectedBtn");
+    const clearRejectedBtnEl = document.getElementById("clearRejectedBtn");
+    const selectionSummaryEl = document.getElementById("selectionSummary");
+    const selectPageBtnEl = document.getElementById("selectPageBtn");
+    const clearSelectedBtnEl = document.getElementById("clearSelectedBtn");
+    const rejectSelectedBtnEl = document.getElementById("rejectSelectedBtn");
+    const unrejectSelectedBtnEl = document.getElementById("unrejectSelectedBtn");
+
+    const rejectedIds = loadRejectedSet();
+    const selectedIds = new Set();
+
+    function norm(v) {
+      return String(v || "").toLowerCase();
+    }
+
+    function primaryIdOf(row) {
+      return String((row && row.primary_id) || "").trim();
+    }
+
+    function loadRejectedSet() {
+      try {
+        const raw = localStorage.getItem(REJECT_KEY);
+        if (!raw) return new Set();
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed)) return new Set();
+        return new Set(parsed.map((item) => String(item || "").trim()).filter(Boolean));
+      } catch (_err) {
+        return new Set();
+      }
+    }
+
+    function saveRejectedSet() {
+      try {
+        localStorage.setItem(REJECT_KEY, JSON.stringify(Array.from(rejectedIds).sort()));
+      } catch (_err) {
+        // noop
+      }
+    }
+
+    function isRejectedRow(row) {
+      const pid = primaryIdOf(row);
+      return Boolean(pid) && rejectedIds.has(pid);
+    }
+
+    function effectiveStatus(row) {
+      if (isRejectedRow(row)) return "rejected";
+      return norm(row.status) || "unknown";
+    }
+
+    function hasImage(row) {
+      return String(row.image_url || "").trim() !== "";
+    }
+
+    function hasDesignations(row) {
+      return Array.isArray(row.designations) && row.designations.length > 0;
+    }
+
+    function hasDescription(row) {
+      const text = String(row.description || "").trim();
+      if (!text) return false;
+      const lowered = norm(text);
+      return lowered !== "no description available." && lowered !== "no description available";
+    }
+
+    function topText() {
+      const selCatalogs = (selection.catalogs || []).join(", ");
+      const selGroups = (selection.object_type_groups || []).join(", ");
+      return `Source JSON: ${jsonPath} | Generated: ${generatedAt || "-"} | HTML built: ${builtAt} | Catalogs: ${selCatalogs || "-"} | Groups: ${selGroups || "-"}`;
+    }
+
+    function computeCounts() {
+      let matched = 0;
+      let noMatch = 0;
+      let rejected = 0;
+      let withImage = 0;
+      let withDesignations = 0;
+
+      for (const row of targets) {
+        const s = effectiveStatus(row);
+        if (s === "matched") matched += 1;
+        else if (s === "no_match") noMatch += 1;
+        else if (s === "rejected") rejected += 1;
+
+        if (hasImage(row)) withImage += 1;
+        if (hasDesignations(row)) withDesignations += 1;
+      }
+
+      return {
+        total: targets.length,
+        matched,
+        no_match: noMatch,
+        rejected,
+        with_image: withImage,
+        with_designations: withDesignations,
+      };
+    }
+
+    function renderStats() {
+      document.getElementById("metaLine").textContent = topText();
+      const counts = computeCounts();
+      const items = [
+        { key: "all", label: "All", value: counts.total },
+        { key: "matched", label: "Matched", value: counts.matched },
+        { key: "no_match", label: "No Match", value: counts.no_match },
+        { key: "rejected", label: "Rejected", value: counts.rejected },
+        { key: "with_image", label: "With Image", value: counts.with_image },
+        { key: "with_designations", label: "With Designations", value: counts.with_designations },
+      ];
+      topStatsEl.innerHTML = items
+        .map((item) => `
+          <button type="button" class="stat-btn ${metricFilter === item.key ? "active" : ""}" data-metric="${item.key}">
+            <strong>${item.label}:</strong> ${item.value}
+          </button>
+        `)
+        .join("");
+    }
+
+    function populateSelect(selectEl, values, allLabel) {
+      const current = selectEl.value || "all";
+      const options = [`<option value="all">${allLabel}</option>`]
+        .concat(values.map((v) => `<option value="${v}">${v}</option>`));
+      selectEl.innerHTML = options.join("");
+      if (values.includes(current)) selectEl.value = current;
+      else selectEl.value = "all";
+    }
+
+    function populateDropdowns() {
+      const catalogs = Array.from(
+        new Set(targets.map((row) => String(row.catalog || "").trim()).filter(Boolean))
+      ).sort((a, b) => a.localeCompare(b));
+
+      const groups = Array.from(
+        new Set(targets.map((row) => String(row.object_type_group || "").trim()).filter(Boolean))
+      ).sort((a, b) => a.localeCompare(b));
+
+      populateSelect(catalogEl, catalogs, "All catalogs");
+      populateSelect(groupEl, groups, "All object groups");
+    }
+
+    function pagePrimaryIds() {
+      return currentPageRows.map(primaryIdOf).filter(Boolean);
+    }
+
+    function selectedOnPageCount() {
+      return pagePrimaryIds().filter((id) => selectedIds.has(id)).length;
+    }
+
+    function allPageItemsSelected() {
+      const ids = pagePrimaryIds();
+      return ids.length > 0 && ids.every((id) => selectedIds.has(id));
+    }
+
+    function updateSelectionControls() {
+      const pageIds = pagePrimaryIds();
+      const selectedOnPage = selectedOnPageCount();
+      selectionSummaryEl.textContent = `${selectedIds.size} selected (${selectedOnPage} on page)`;
+
+      selectPageBtnEl.disabled = pageIds.length === 0;
+      selectPageBtnEl.textContent = allPageItemsSelected() ? "Unselect page" : "Select all on page";
+      clearSelectedBtnEl.disabled = selectedIds.size === 0;
+      rejectSelectedBtnEl.disabled = selectedIds.size === 0;
+      unrejectSelectedBtnEl.disabled = selectedIds.size === 0;
+    }
+
+    function togglePageSelection() {
+      const ids = pagePrimaryIds();
+      if (!ids.length) return;
+      const allSelected = ids.every((id) => selectedIds.has(id));
+      if (allSelected) {
+        ids.forEach((id) => selectedIds.delete(id));
+      } else {
+        ids.forEach((id) => selectedIds.add(id));
+      }
+      render();
+    }
+
+    function applyBulkReject(shouldReject) {
+      if (!selectedIds.size) return;
+      let changed = 0;
+      for (const id of selectedIds) {
+        if (shouldReject) {
+          if (!rejectedIds.has(id)) {
+            rejectedIds.add(id);
+            changed += 1;
+          }
+        } else if (rejectedIds.has(id)) {
+          rejectedIds.delete(id);
+          changed += 1;
+        }
+      }
+      if (!changed) return;
+      saveRejectedSet();
+      currentPage = 1;
+      renderStats();
+      render();
+    }
+
+    function passesMetricFilter(row) {
+      if (metricFilter === "all") return true;
+      if (metricFilter === "matched") return effectiveStatus(row) === "matched";
+      if (metricFilter === "no_match") return effectiveStatus(row) === "no_match";
+      if (metricFilter === "rejected") return effectiveStatus(row) === "rejected";
+      if (metricFilter === "with_image") return hasImage(row);
+      if (metricFilter === "with_designations") return hasDesignations(row);
+      return true;
+    }
+
+    function filtered() {
+      const q = norm(searchEl.value).trim();
+      const status = statusEl.value;
+      const selectedCatalog = catalogEl.value;
+      const selectedGroup = groupEl.value;
+      const descMode = descFilterEl.value;
+      const imageOnly = imageOnlyEl.checked;
+
+      let rows = targets.filter((row) => {
+        if (status !== "all" && effectiveStatus(row) !== status) return false;
+        if (!passesMetricFilter(row)) return false;
+
+        const catalogValue = String(row.catalog || "").trim();
+        if (selectedCatalog !== "all" && catalogValue !== selectedCatalog) return false;
+
+        const groupValue = String(row.object_type_group || "").trim();
+        if (selectedGroup !== "all" && groupValue !== selectedGroup) return false;
+
+        if (descMode === "with" && !hasDescription(row)) return false;
+        if (descMode === "without" && hasDescription(row)) return false;
+
+        if (imageOnly && !hasImage(row)) return false;
+
+        if (!q) return true;
+        const fields = [
+          row.primary_id,
+          row.wikipedia_title,
+          row.common_name,
+          row.description,
+          row.object_type_group,
+          row.catalog,
+          Array.isArray(row.designations) ? row.designations.join(" ") : "",
+        ].map(norm);
+        return fields.some((field) => field.includes(q));
+      });
+
+      if (sortEl.value === "score_desc") {
+        rows.sort((a, b) => Number(b.match_score || 0) - Number(a.match_score || 0));
+      } else if (sortEl.value === "score_asc") {
+        rows.sort((a, b) => Number(a.match_score || 0) - Number(b.match_score || 0));
+      } else if (sortEl.value === "title_asc") {
+        rows.sort((a, b) => String(a.wikipedia_title || a.primary_id || "").localeCompare(String(b.wikipedia_title || b.primary_id || "")));
+      } else if (sortEl.value === "primary_asc") {
+        rows.sort((a, b) => String(a.primary_id || "").localeCompare(String(b.primary_id || "")));
+      }
+
+      return rows;
+    }
+
+    function card(row) {
+      const title = row.wikipedia_title || row.primary_id || "Unknown";
+      const reviewStatus = effectiveStatus(row);
+      const statusClass = reviewStatus === "matched" ? "matched" : (reviewStatus === "rejected" ? "rejected" : "no_match");
+      const statusLabel = reviewStatus === "rejected" ? "Rejected" : (row.status || "unknown");
+      const desc = hasDescription(row) ? String(row.description || "").trim() : "No description available.";
+      const image = String(row.image_url || "").trim();
+      const wiki = String(row.wikipedia_url || "").trim();
+      const designations = Array.isArray(row.designations) ? row.designations.slice(0, 6) : [];
+      const primaryId = primaryIdOf(row);
+      const pidEncoded = encodeURIComponent(primaryId);
+      const rejected = reviewStatus === "rejected";
+      const isSelected = Boolean(primaryId) && selectedIds.has(primaryId);
+
+      const imgHtml = image
+        ? `<img loading="lazy" src="${image}" alt="${title}" />`
+        : `<span>No image</span>`;
+
+      const chips = [
+        `catalog: ${row.catalog || "-"}`,
+        `group: ${row.object_type_group || "-"}`,
+        `score: ${row.match_score ?? "-"}`,
+        `sentences: ${row.description_sentence_count ?? 0}`,
+      ];
+      if (rejected) chips.push("review: rejected");
+      const chipHtml = chips.map((x) => `<span class="chip">${x}</span>`).join("");
+
+      const designationHtml = designations.length
+        ? `<div class="meta-row">${designations.map((d) => `<span class="chip">${d}</span>`).join("")}</div>`
+        : "";
+
+      const linkHtml = wiki ? `<a class="link" target="_blank" rel="noopener noreferrer" href="${wiki}">Open Wikipedia page</a>` : "";
+      const subtitle = `${row.primary_id || "-"} • ${row.common_name || "No common name"}`;
+      const rejectBtnHtml = primaryId
+        ? `<button type="button" class="action-btn reject-btn ${rejected ? "active" : ""}" data-reject-id="${pidEncoded}">${rejected ? "Unreject" : "Reject"}</button>`
+        : "";
+      const selectHtml = primaryId
+        ? `<label class="select-item"><input type="checkbox" data-select-id="${pidEncoded}" ${isSelected ? "checked" : ""} /> Select</label>`
+        : "";
+
+      return `
+        <article class="card">
+          <div class="img-wrap">${imgHtml}</div>
+          <div class="body">
+            <h3 class="title">${title}</h3>
+            <p class="subtitle">${subtitle}</p>
+            <span class="status ${statusClass}">${statusLabel}</span>
+            <p class="desc">${desc}</p>
+            <div class="action-row">${rejectBtnHtml}${selectHtml}</div>
+            ${linkHtml}
+            <div class="meta-row">${chipHtml}</div>
+            ${designationHtml}
+          </div>
+        </article>
+      `;
+    }
+
+    function render() {
+      resultSummaryEl.classList.remove("error");
+      const rows = filtered();
+      const pageSize = Number(pageSizeEl.value || 48);
+      const totalPages = Math.max(1, Math.ceil(rows.length / pageSize));
+      if (currentPage > totalPages) currentPage = totalPages;
+      if (currentPage < 1) currentPage = 1;
+
+      const start = (currentPage - 1) * pageSize;
+      const end = start + pageSize;
+      const pageRows = rows.slice(start, end);
+      currentPageRows = pageRows;
+
+      const metricText = metricFilter === "all" ? "all metrics" : `metric=${metricFilter}`;
+      resultSummaryEl.textContent = `Showing ${pageRows.length} of ${rows.length} filtered targets (${targets.length} total, ${metricText}, ${rejectedIds.size} rejected locally, ${selectedIds.size} selected).`;
+      pageLabelEl.textContent = `Page ${currentPage} / ${totalPages}`;
+      prevBtnEl.disabled = currentPage <= 1;
+      nextBtnEl.disabled = currentPage >= totalPages;
+
+      if (!pageRows.length) {
+        cardsEl.innerHTML = "";
+        resultSummaryEl.textContent = "No targets match this filter.";
+        updateSelectionControls();
+        return;
+      }
+      cardsEl.innerHTML = pageRows.map(card).join("");
+      updateSelectionControls();
+    }
+
+    function downloadJson(filename, obj) {
+      const blob = new Blob([JSON.stringify(obj, null, 2)], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    }
+
+    function showLoadError(message) {
+      cardsEl.innerHTML = "";
+      currentPageRows = [];
+      pageLabelEl.textContent = "";
+      prevBtnEl.disabled = true;
+      nextBtnEl.disabled = true;
+      resultSummaryEl.classList.add("error");
+      resultSummaryEl.textContent = message;
+      updateSelectionControls();
+    }
+
+    async function loadPayload() {
+      resultSummaryEl.classList.remove("error");
+      resultSummaryEl.textContent = `Loading enrichment data from ${jsonPath} ...`;
+      try {
+        const response = await fetch(jsonPath, { cache: "no-store" });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+        const loaded = await response.json();
+        if (!loaded || typeof loaded !== "object") throw new Error("JSON payload is not an object");
+
+        payload = loaded;
+        targets = Array.isArray(payload.targets) ? payload.targets : [];
+        generatedAt = payload.generated_at_utc || "";
+        selection = payload.selection || {};
+        stats = payload.stats || {};
+
+        const validIds = new Set(targets.map(primaryIdOf).filter(Boolean));
+        for (const id of Array.from(selectedIds)) {
+          if (!validIds.has(id)) selectedIds.delete(id);
+        }
+
+        populateDropdowns();
+        renderStats();
+        render();
+      } catch (error) {
+        console.error(error);
+        const hint = window.location.protocol === "file:"
+          ? " If you opened this via file://, start a local server (python -m http.server 8000) and open http://127.0.0.1:8000/data/wikipedia_catalog_enrichment_review.html."
+          : "";
+        showLoadError(`Failed to load enrichment JSON at ${jsonPath}. ${error.message || error}.${hint}`);
+      }
+    }
+
+    [searchEl, statusEl, catalogEl, groupEl, descFilterEl, sortEl, imageOnlyEl, pageSizeEl].forEach((el) => {
+      el.addEventListener("input", () => {
+        currentPage = 1;
+        render();
+      });
+      el.addEventListener("change", () => {
+        currentPage = 1;
+        render();
+      });
+    });
+
+    topStatsEl.addEventListener("click", (event) => {
+      const button = event.target.closest("button[data-metric]");
+      if (!button) return;
+      const next = String(button.getAttribute("data-metric") || "all");
+      metricFilter = metricFilter === next ? "all" : next;
+      currentPage = 1;
+      renderStats();
+      render();
+    });
+
+    cardsEl.addEventListener("click", (event) => {
+      const btn = event.target.closest("button[data-reject-id]");
+      if (!btn) return;
+      const encoded = btn.getAttribute("data-reject-id") || "";
+      const primaryId = decodeURIComponent(encoded);
+      if (!primaryId) return;
+      if (rejectedIds.has(primaryId)) rejectedIds.delete(primaryId);
+      else rejectedIds.add(primaryId);
+      saveRejectedSet();
+      currentPage = 1;
+      renderStats();
+      render();
+    });
+
+    cardsEl.addEventListener("change", (event) => {
+      const input = event.target.closest("input[type='checkbox'][data-select-id]");
+      if (!input) return;
+      const encoded = input.getAttribute("data-select-id") || "";
+      const primaryId = decodeURIComponent(encoded);
+      if (!primaryId) return;
+      if (input.checked) selectedIds.add(primaryId);
+      else selectedIds.delete(primaryId);
+      render();
+    });
+
+    selectPageBtnEl.addEventListener("click", () => {
+      togglePageSelection();
+    });
+
+    clearSelectedBtnEl.addEventListener("click", () => {
+      if (!selectedIds.size) return;
+      selectedIds.clear();
+      render();
+    });
+
+    rejectSelectedBtnEl.addEventListener("click", () => {
+      applyBulkReject(true);
+    });
+
+    unrejectSelectedBtnEl.addEventListener("click", () => {
+      applyBulkReject(false);
+    });
+
+    exportRejectedBtnEl.addEventListener("click", () => {
+      const ids = Array.from(rejectedIds).sort();
+      const rejectedTargets = targets.filter((row) => ids.includes(String(row.primary_id || "").trim()));
+      const exportPayload = {
+        exported_at_utc: new Date().toISOString(),
+        source_json: jsonPath,
+        rejected_count: ids.length,
+        rejected_primary_ids: ids,
+        rejected_targets: rejectedTargets,
+      };
+      downloadJson("wikipedia_catalog_rejected_targets.json", exportPayload);
+    });
+
+    clearRejectedBtnEl.addEventListener("click", () => {
+      if (!rejectedIds.size) return;
+      if (!window.confirm(`Clear ${rejectedIds.size} rejected targets?`)) return;
+      rejectedIds.clear();
+      saveRejectedSet();
+      currentPage = 1;
+      renderStats();
+      render();
+    });
+
+    prevBtnEl.addEventListener("click", () => {
+      currentPage -= 1;
+      render();
+    });
+    nextBtnEl.addEventListener("click", () => {
+      currentPage += 1;
+      render();
+    });
+
+    updateSelectionControls();
+    loadPayload();
+  </script>
+</body>
+</html>

--- a/scripts/apply_wikipedia_catalog_enrichment.py
+++ b/scripts/apply_wikipedia_catalog_enrichment.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from catalog_ingestion import ENRICHED_OPTIONAL_COLUMNS, OPTIONAL_COLUMNS, REQUIRED_COLUMNS
+
+CACHE_COLUMNS = REQUIRED_COLUMNS + OPTIONAL_COLUMNS + ENRICHED_OPTIONAL_COLUMNS
+NUMERIC_COLUMNS = {"ra_deg", "dec_deg", "dist_value", "redshift"}
+STRING_COLUMNS = [column for column in CACHE_COLUMNS if column not in NUMERIC_COLUMNS]
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _normalize_text(value: Any) -> str:
+    return "".join(ch for ch in str(value or "").lower() if ch.isalnum())
+
+
+def _to_list(raw: Any) -> list[str]:
+    if isinstance(raw, list):
+        values = [str(item).strip() for item in raw]
+        return [value for value in values if value]
+
+    text = str(raw or "").strip()
+    if not text:
+        return []
+
+    pieces: list[str] = []
+    if ";" in text:
+        pieces = [part.strip() for part in text.split(";")]
+    elif "," in text:
+        pieces = [part.strip() for part in text.split(",")]
+    else:
+        pieces = [text]
+
+    return [piece for piece in pieces if piece]
+
+
+def _dedupe_preserve_order(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        cleaned = str(value or "").strip()
+        if not cleaned:
+            continue
+        if cleaned in seen:
+            continue
+        seen.add(cleaned)
+        ordered.append(cleaned)
+    return ordered
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        number = float(value)
+        if math.isnan(number):
+            return None
+        return number
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        number = float(text)
+    except ValueError:
+        return None
+    if math.isnan(number):
+        return None
+    return number
+
+
+def _infer_catalog(primary_id: str) -> str:
+    text = str(primary_id or "").strip().upper()
+    if text.startswith("NGC "):
+        return "NGC"
+    if text.startswith("IC "):
+        return "IC"
+    if text.startswith("SH2-"):
+        return "SH2"
+    if text.startswith("M") and text[1:].strip().replace(" ", "").isdigit():
+        return "M"
+    return "WIKI"
+
+
+def _parse_enrichment_row(row: dict[str, Any]) -> dict[str, Any]:
+    catalog_enrichment = row.get("catalog_enrichment")
+    if not isinstance(catalog_enrichment, dict):
+        catalog_enrichment = {}
+
+    aliases = _to_list(catalog_enrichment.get("aliases", []))
+    designations = _to_list(row.get("designations", []))
+    aliases = _dedupe_preserve_order(aliases + designations)
+
+    emission_lines = _dedupe_preserve_order(_to_list(catalog_enrichment.get("emission_lines", [])))
+
+    info_url = str(catalog_enrichment.get("info_url", "")).strip()
+    if not info_url:
+        info_url = str(row.get("wikipedia_url", "")).strip()
+
+    description = str(catalog_enrichment.get("description", "")).strip()
+    if not description:
+        description = str(row.get("description", "")).strip()
+
+    image_url = str(catalog_enrichment.get("image_url", "")).strip()
+    if not image_url:
+        image_url = str(row.get("image_url", "")).strip()
+
+    return {
+        "common_name": str(catalog_enrichment.get("common_name", "")).strip(),
+        "object_type": str(catalog_enrichment.get("object_type", "")).strip(),
+        "ra_deg": _coerce_float(catalog_enrichment.get("ra_deg")),
+        "dec_deg": _coerce_float(catalog_enrichment.get("dec_deg")),
+        "constellation": str(catalog_enrichment.get("constellation", "")).strip(),
+        "aliases": aliases,
+        "image_url": image_url,
+        "image_attribution_url": str(catalog_enrichment.get("image_attribution_url", "")).strip(),
+        "description": description,
+        "info_url": info_url,
+        "emission_lines": emission_lines,
+        "wikipedia_primary_id": str(catalog_enrichment.get("wikipedia_primary_id", "")).strip(),
+        "wikipedia_catalog": str(catalog_enrichment.get("wikipedia_catalog", "")).strip().upper(),
+    }
+
+
+def _has_enrichment_payload(enrichment: dict[str, Any]) -> bool:
+    return any(
+        [
+            bool(enrichment.get("common_name")),
+            bool(enrichment.get("object_type")),
+            enrichment.get("ra_deg") is not None,
+            enrichment.get("dec_deg") is not None,
+            bool(enrichment.get("constellation")),
+            bool(enrichment.get("aliases")),
+            bool(enrichment.get("image_url")),
+            bool(enrichment.get("image_attribution_url")),
+            bool(enrichment.get("description")),
+            bool(enrichment.get("info_url")),
+            bool(enrichment.get("emission_lines")),
+        ]
+    )
+
+
+def _make_empty_row() -> dict[str, Any]:
+    row: dict[str, Any] = {}
+    for column in STRING_COLUMNS:
+        row[column] = ""
+    for column in NUMERIC_COLUMNS:
+        row[column] = float("nan")
+    return row
+
+
+def _prepare_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    prepared = frame.copy()
+    for column in CACHE_COLUMNS:
+        if column not in prepared.columns:
+            prepared[column] = "" if column in STRING_COLUMNS else float("nan")
+
+    prepared = prepared[CACHE_COLUMNS]
+    for column in STRING_COLUMNS:
+        prepared[column] = prepared[column].fillna("").astype(str).str.strip()
+    for column in NUMERIC_COLUMNS:
+        prepared[column] = pd.to_numeric(prepared[column], errors="coerce")
+    return prepared
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Merge wikipedia_catalog_enrichment.json into dso_catalog_cache.parquet "
+            "by updating matching primary_id rows and inserting missing rows."
+        ),
+    )
+    parser.add_argument(
+        "--catalog-cache-path",
+        type=Path,
+        default=Path("data/dso_catalog_cache.parquet"),
+        help="Input parquet cache path.",
+    )
+    parser.add_argument(
+        "--enrichment-path",
+        type=Path,
+        default=Path("data/wikipedia_catalog_enrichment.json"),
+        help="Wikipedia enrichment JSON path.",
+    )
+    parser.add_argument(
+        "--output-cache-path",
+        type=Path,
+        default=None,
+        help="Output parquet path (default: overwrite --catalog-cache-path).",
+    )
+    parser.add_argument(
+        "--metadata-path",
+        type=Path,
+        default=Path("data/dso_catalog_cache_meta.json"),
+        help="Metadata JSON path to refresh with row counts.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Compute and print merge stats without writing parquet or metadata.",
+    )
+    return parser
+
+
+def main() -> None:
+    args = _build_arg_parser().parse_args()
+
+    cache_path = args.catalog_cache_path
+    enrichment_path = args.enrichment_path
+    output_cache_path = args.output_cache_path or cache_path
+    metadata_path = args.metadata_path
+
+    if not cache_path.exists():
+        raise FileNotFoundError(f"Catalog cache not found: {cache_path}")
+    if not enrichment_path.exists():
+        raise FileNotFoundError(f"Wikipedia enrichment JSON not found: {enrichment_path}")
+
+    cache_frame = _prepare_frame(pd.read_parquet(cache_path))
+    payload = json.loads(enrichment_path.read_text(encoding="utf-8"))
+    targets = payload.get("targets", [])
+    if not isinstance(targets, list):
+        raise ValueError("Enrichment payload is missing a valid 'targets' array.")
+
+    cache_frame["primary_id"] = cache_frame["primary_id"].fillna("").astype(str).str.strip()
+    id_to_index = {pid: idx for idx, pid in cache_frame["primary_id"].items() if pid}
+
+    updates_by_field: dict[str, int] = {}
+    update_rows = 0
+    inserted_rows = 0
+    skipped_rows = 0
+    skipped_inserts_missing_coords = 0
+    insert_candidates: list[dict[str, Any]] = []
+
+    for item in targets:
+        if not isinstance(item, dict):
+            skipped_rows += 1
+            continue
+
+        primary_id = str(item.get("primary_id", "")).strip()
+        if not primary_id:
+            skipped_rows += 1
+            continue
+
+        enrichment = _parse_enrichment_row(item)
+        if not _has_enrichment_payload(enrichment):
+            skipped_rows += 1
+            continue
+
+        if primary_id in id_to_index:
+            idx = id_to_index[primary_id]
+            row_changed = False
+
+            for field in ("common_name", "object_type", "constellation", "image_url", "image_attribution_url", "description", "info_url"):
+                new_value = str(enrichment.get(field, "")).strip()
+                if not new_value:
+                    continue
+                old_value = str(cache_frame.at[idx, field]).strip()
+                if old_value == new_value:
+                    continue
+                cache_frame.at[idx, field] = new_value
+                updates_by_field[field] = updates_by_field.get(field, 0) + 1
+                row_changed = True
+
+            for field in ("ra_deg", "dec_deg"):
+                new_number = _coerce_float(enrichment.get(field))
+                if new_number is None:
+                    continue
+                old_number = _coerce_float(cache_frame.at[idx, field])
+                if old_number is not None and abs(old_number - new_number) < 1e-12:
+                    continue
+                cache_frame.at[idx, field] = new_number
+                updates_by_field[field] = updates_by_field.get(field, 0) + 1
+                row_changed = True
+
+            alias_additions = _to_list(enrichment.get("aliases", []))
+            if alias_additions:
+                existing_aliases = _to_list(cache_frame.at[idx, "aliases"])
+                merged_aliases = _dedupe_preserve_order(existing_aliases + alias_additions)
+                merged_alias_text = ";".join(merged_aliases)
+                if merged_alias_text != str(cache_frame.at[idx, "aliases"]).strip():
+                    cache_frame.at[idx, "aliases"] = merged_alias_text
+                    updates_by_field["aliases"] = updates_by_field.get("aliases", 0) + 1
+                    row_changed = True
+
+            emission_additions = _to_list(enrichment.get("emission_lines", []))
+            if emission_additions:
+                existing_emission = _to_list(cache_frame.at[idx, "emission_lines"])
+                merged_emission = _dedupe_preserve_order(existing_emission + emission_additions)
+                merged_emission_text = "; ".join(merged_emission)
+                if merged_emission_text != str(cache_frame.at[idx, "emission_lines"]).strip():
+                    cache_frame.at[idx, "emission_lines"] = merged_emission_text
+                    updates_by_field["emission_lines"] = updates_by_field.get("emission_lines", 0) + 1
+                    row_changed = True
+
+            if row_changed:
+                update_rows += 1
+            continue
+
+        ra_deg = _coerce_float(enrichment.get("ra_deg"))
+        dec_deg = _coerce_float(enrichment.get("dec_deg"))
+        if ra_deg is None or dec_deg is None:
+            skipped_inserts_missing_coords += 1
+            continue
+
+        new_row = _make_empty_row()
+        new_row["primary_id"] = primary_id
+        new_row["catalog"] = (
+            str(item.get("catalog", "")).strip().upper()
+            or str(enrichment.get("wikipedia_catalog", "")).strip().upper()
+            or _infer_catalog(primary_id)
+        )
+        new_row["common_name"] = str(enrichment.get("common_name", "")).strip()
+        new_row["object_type"] = str(enrichment.get("object_type", "")).strip()
+        new_row["ra_deg"] = ra_deg
+        new_row["dec_deg"] = dec_deg
+        new_row["constellation"] = str(enrichment.get("constellation", "")).strip()
+        new_row["aliases"] = ";".join(_to_list(enrichment.get("aliases", [])))
+        new_row["object_type_group"] = str(item.get("object_type_group", "")).strip()
+        new_row["image_url"] = str(enrichment.get("image_url", "")).strip()
+        new_row["image_attribution_url"] = str(enrichment.get("image_attribution_url", "")).strip()
+        new_row["description"] = str(enrichment.get("description", "")).strip()
+        new_row["info_url"] = str(enrichment.get("info_url", "")).strip()
+        new_row["emission_lines"] = "; ".join(_to_list(enrichment.get("emission_lines", [])))
+        insert_candidates.append(new_row)
+        inserted_rows += 1
+
+    if insert_candidates:
+        cache_frame = pd.concat([cache_frame, pd.DataFrame.from_records(insert_candidates)], ignore_index=True)
+
+    cache_frame = _prepare_frame(cache_frame)
+    cache_frame = cache_frame[cache_frame["primary_id"] != ""]
+    cache_frame = cache_frame.drop_duplicates(subset=["primary_id"], keep="first")
+    cache_frame = cache_frame.sort_values(by=["catalog", "primary_id"], ascending=[True, True]).reset_index(drop=True)
+
+    summary = {
+        "cache_path": str(cache_path),
+        "enrichment_path": str(enrichment_path),
+        "output_cache_path": str(output_cache_path),
+        "targets_seen": int(len(targets)),
+        "rows_updated": int(update_rows),
+        "rows_inserted": int(inserted_rows),
+        "skipped_rows_without_payload": int(skipped_rows),
+        "skipped_inserts_missing_coordinates": int(skipped_inserts_missing_coords),
+        "field_updates": {key: int(value) for key, value in sorted(updates_by_field.items())},
+        "result_row_count": int(len(cache_frame)),
+    }
+
+    print("[wikipedia-merge] summary")
+    print(json.dumps(summary, indent=2))
+
+    if args.dry_run:
+        print("[wikipedia-merge] dry-run enabled; no files written")
+        return
+
+    output_cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_frame.to_parquet(output_cache_path, index=False)
+    print(f"[wikipedia-merge] wrote parquet: {output_cache_path}")
+
+    metadata: dict[str, Any] = {}
+    if metadata_path.exists():
+        try:
+            loaded = json.loads(metadata_path.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                metadata = loaded
+        except (OSError, json.JSONDecodeError):
+            metadata = {}
+
+    metadata["cache"] = str(output_cache_path)
+    metadata["loaded_at_utc"] = _utc_now_iso()
+    metadata["row_count"] = int(len(cache_frame))
+    metadata["catalog_counts"] = {
+        str(key): int(value) for key, value in cache_frame["catalog"].value_counts().to_dict().items()
+    }
+    metadata["wikipedia_enrichment_merge"] = {
+        "applied_at_utc": _utc_now_iso(),
+        "enrichment_path": str(enrichment_path),
+        "targets_seen": int(len(targets)),
+        "rows_updated": int(update_rows),
+        "rows_inserted": int(inserted_rows),
+        "skipped_rows_without_payload": int(skipped_rows),
+        "skipped_inserts_missing_coordinates": int(skipped_inserts_missing_coords),
+        "field_updates": {key: int(value) for key, value in sorted(updates_by_field.items())},
+    }
+
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    metadata_path.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+    print(f"[wikipedia-merge] wrote metadata: {metadata_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_wikipedia_catalog_enrichment.py
+++ b/scripts/build_wikipedia_catalog_enrichment.py
@@ -1,0 +1,2273 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import re
+import subprocess
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from collections.abc import Callable
+from urllib.parse import quote, unquote, urlencode, urlparse
+
+import pandas as pd
+
+WIKIPEDIA_API_URL = "https://en.wikipedia.org/w/api.php"
+WIKIPEDIA_SUMMARY_URL = "https://en.wikipedia.org/api/rest_v1/page/summary/{title}"
+
+DEFAULT_INCLUDE_CATALOGS = ("M", "SH2")
+DEFAULT_INCLUDE_GROUPS = ("bright nebula", "dark nebula")
+
+ASTRO_HINT_TOKENS = (
+    "astronomy",
+    "messier",
+    "sharpless",
+    "nebula",
+    "galaxy",
+    "cluster",
+    "supernova",
+    "stellar",
+    "h ii",
+    "hii",
+    "interstellar",
+    "deep sky",
+)
+DISAMBIGUATION_HINTS = (
+    "disambiguation",
+    "may refer to",
+    "can refer to",
+)
+NEBULA_TOPIC_TOKENS = (
+    "nebula",
+    "nebulous",
+    "h ii region",
+    "emission region",
+    "molecular cloud",
+    "interstellar cloud",
+    "dark cloud",
+    "reflection nebula",
+    "planetary nebula",
+    "supernova remnant",
+)
+STAR_TOPIC_TOKENS = (
+    "star",
+    "binary star",
+    "multiple star",
+    "variable star",
+    "stellar",
+    "spectral type",
+    "main sequence",
+    "giant star",
+    "white dwarf",
+)
+MESSIER_OBJECT_HINT_TOKENS = (
+    "galaxy",
+    "nebula",
+    "star",
+    "cluster",
+    "globular",
+    "open cluster",
+    "planetary nebula",
+    "supernova remnant",
+)
+
+DESIGNATION_KEY_HINTS = (
+    "designation",
+    "designations",
+    "othername",
+    "othernames",
+    "alias",
+    "aliases",
+    "altname",
+    "alternatename",
+    "otherid",
+    "otherids",
+    "catalog",
+    "catalogue",
+    "name",
+    "names",
+)
+DESIGNATION_KEY_EXCLUDES = (
+    "image",
+    "caption",
+    "discover",
+    "distance",
+    "magnitude",
+    "constellation",
+    "epoch",
+    "ra",
+    "dec",
+    "radius",
+    "mass",
+    "temperature",
+)
+
+BR_TAG_RE = re.compile(r"<br\s*/?>", flags=re.IGNORECASE)
+REF_TAG_RE = re.compile(r"<ref[^>/]*/>|<ref[^>]*>.*?</ref>", flags=re.IGNORECASE | re.DOTALL)
+COMMENT_RE = re.compile(r"<!--.*?-->", flags=re.DOTALL)
+TEMPLATE_RE = re.compile(r"\{\{[^{}]*\}\}")
+WIKILINK_PIPED_RE = re.compile(r"\[\[[^\]|]+\|([^\]]+)\]\]")
+WIKILINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
+HTML_TAG_RE = re.compile(r"<[^>]+>")
+SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
+NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
+NAME_PREFIX_RE = re.compile(r"^\s*NAME\s+(.+)$", flags=re.IGNORECASE)
+DESIGNATION_INVALID_CHAR_RE = re.compile(r"[^A-Za-z0-9+\-./() ]+")
+NUMBER_RE = re.compile(r"[-+]?\d+(?:\.\d+)?")
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _normalize_text(value: str | None) -> str:
+    return NON_ALNUM_RE.sub("", str(value or "").strip().lower())
+
+
+def _dedupe_preserve_order(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        cleaned = str(value).strip()
+        if not cleaned:
+            continue
+        if cleaned in seen:
+            continue
+        seen.add(cleaned)
+        ordered.append(cleaned)
+    return ordered
+
+
+def _split_aliases(raw_aliases: Any) -> list[str]:
+    text = str(raw_aliases or "").strip()
+    if not text:
+        return []
+    parts = [part.strip() for part in text.split(";")]
+    return [part for part in parts if part]
+
+
+def _strip_name_prefix(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    match = NAME_PREFIX_RE.match(text)
+    if not match:
+        return text
+    stripped = str(match.group(1) or "").strip()
+    return stripped or text
+
+
+def _name_variants(value: Any, *, include_name_prefixed_original: bool = False) -> list[str]:
+    cleaned = str(value or "").strip()
+    if not cleaned:
+        return []
+    stripped = _strip_name_prefix(cleaned)
+    if stripped and stripped != cleaned:
+        if include_name_prefixed_original:
+            return [cleaned, stripped]
+        return [stripped]
+    return [cleaned]
+
+
+def _with_name_prefix_variants(
+    values: list[str],
+    *,
+    include_name_prefixed_original: bool = False,
+) -> list[str]:
+    expanded: list[str] = []
+    for value in values:
+        expanded.extend(
+            _name_variants(
+                value,
+                include_name_prefixed_original=include_name_prefixed_original,
+            )
+        )
+    return _dedupe_preserve_order(expanded)
+
+
+def _strip_html(text: str) -> str:
+    return re.sub(r"<[^>]+>", "", text)
+
+
+def _sentence_list(text: str) -> list[str]:
+    compact = " ".join(str(text or "").split())
+    if not compact:
+        return []
+    sentences = [segment.strip() for segment in SENTENCE_SPLIT_RE.split(compact) if segment.strip()]
+    return sentences
+
+
+def _truncate(text: str, max_len: int = 120) -> str:
+    value = " ".join(str(text or "").split())
+    if len(value) <= max_len:
+        return value
+    return f"{value[: max_len - 3]}..."
+
+
+def _description_3_to_4_sentences(*texts: str) -> str:
+    best: list[str] = []
+    for text in texts:
+        sentences = _sentence_list(text)
+        if len(sentences) >= 4:
+            return " ".join(sentences[:4])
+        if len(sentences) >= 3:
+            return " ".join(sentences[:3])
+        if len(sentences) > len(best):
+            best = sentences
+    if not best:
+        return ""
+    return " ".join(best[:4])
+
+
+def _append_sentence_if_missing(base_text: str, sentence: str) -> str:
+    base = str(base_text or "").strip()
+    extra = str(sentence or "").strip()
+    if not extra:
+        return base
+    if not extra.endswith("."):
+        extra = f"{extra}."
+    if not base:
+        return extra
+
+    normalized_base = _normalize_text(base)
+    normalized_extra = _normalize_text(extra)
+    if normalized_extra and normalized_extra in normalized_base:
+        return base
+    return f"{base} {extra}".strip()
+
+
+def _looks_disambiguation(title: str, extract: str) -> bool:
+    content = f"{title} {extract}".lower()
+    return any(token in content for token in DISAMBIGUATION_HINTS)
+
+
+def _looks_astronomy(summary_text: str) -> bool:
+    lowered = summary_text.lower()
+    return any(token in lowered for token in ASTRO_HINT_TOKENS)
+
+
+def _page_topic_label(title: str, extract: str, short_description: str) -> str:
+    lowered = f"{title} {extract} {short_description}".lower()
+    nebula_hits = sum(1 for token in NEBULA_TOPIC_TOKENS if token in lowered)
+    star_hits = sum(1 for token in STAR_TOPIC_TOKENS if token in lowered)
+
+    if nebula_hits > star_hits and nebula_hits > 0:
+        return "nebula"
+    if star_hits > nebula_hits and star_hits > 0:
+        return "star"
+    return "other"
+
+
+def _looks_messier_object_page(title: str, extract: str, short_description: str) -> bool:
+    lowered = f"{title} {extract} {short_description}".lower()
+    return any(token in lowered for token in MESSIER_OBJECT_HINT_TOKENS)
+
+
+def _is_m_shorthand_query(query: str, messier_number: int | None) -> bool:
+    if messier_number is None:
+        return False
+    match = re.fullmatch(r"m\s*0*([0-9]+)", str(query or "").strip(), flags=re.IGNORECASE)
+    if not match:
+        return False
+    try:
+        return int(match.group(1)) == int(messier_number)
+    except ValueError:
+        return False
+
+
+def _row_prefers_nebula(row: dict[str, Any]) -> bool:
+    primary_id = _strip_name_prefix(str(row.get("primary_id", "")).strip())
+    object_type_group = str(row.get("object_type_group", "")).strip().lower()
+    object_type = str(row.get("object_type", "")).strip().lower()
+    common_name = str(row.get("common_name", "")).strip().lower()
+
+    if "nebula" in object_type_group:
+        return True
+    if "nebula" in object_type:
+        return True
+    if "nebula" in common_name:
+        return True
+    if primary_id.lower().startswith("sh2-"):
+        return True
+    return False
+
+
+def _clean_wikitext_value(raw_value: str) -> str:
+    text = str(raw_value or "")
+    text = COMMENT_RE.sub(" ", text)
+    text = REF_TAG_RE.sub(" ", text)
+    text = BR_TAG_RE.sub(";", text)
+
+    # Collapse trivial templates; run repeatedly so nested simple templates reduce.
+    for _ in range(6):
+        reduced = TEMPLATE_RE.sub(" ", text)
+        if reduced == text:
+            break
+        text = reduced
+
+    text = WIKILINK_PIPED_RE.sub(r"\1", text)
+    text = WIKILINK_RE.sub(r"\1", text)
+    text = HTML_TAG_RE.sub(" ", text)
+    text = html.unescape(text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def _clean_designation_token(token: str) -> str:
+    cleaned = str(token or "").strip().strip(" ,;:.")
+    cleaned = cleaned.replace("''", "").replace("'''", "")
+    cleaned = cleaned.replace("{{", " ").replace("}}", " ")
+    cleaned = cleaned.replace("[[", " ").replace("]]", " ")
+    cleaned = cleaned.replace("|", " ")
+    cleaned = DESIGNATION_INVALID_CHAR_RE.sub(" ", cleaned)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    cleaned = cleaned.strip(" ,;:.\"'")
+    return cleaned
+
+
+def _extract_infobox_block(wikitext: str) -> str:
+    source = str(wikitext or "")
+    start = source.lower().find("{{infobox")
+    if start < 0:
+        return ""
+
+    depth = 0
+    index = start
+    while index < len(source) - 1:
+        pair = source[index:index + 2]
+        if pair == "{{":
+            depth += 1
+            index += 2
+            continue
+        if pair == "}}":
+            depth -= 1
+            index += 2
+            if depth <= 0:
+                return source[start:index]
+            continue
+        index += 1
+    return ""
+
+
+def _parse_infobox_fields(infobox_block: str) -> list[tuple[str, str]]:
+    if not infobox_block.strip():
+        return []
+
+    fields: list[tuple[str, str]] = []
+    current_key: str | None = None
+    current_value_lines: list[str] = []
+
+    def _flush() -> None:
+        nonlocal current_key, current_value_lines
+        if current_key is None:
+            return
+        joined = "\n".join(current_value_lines).strip()
+        fields.append((current_key, joined))
+        current_key = None
+        current_value_lines = []
+
+    for raw_line in infobox_block.splitlines():
+        line = raw_line.rstrip("\n")
+        stripped = line.strip()
+        if stripped.startswith("|"):
+            _flush()
+            body = stripped[1:]
+            if "=" not in body:
+                continue
+            key, value = body.split("=", 1)
+            key = key.strip()
+            if not key:
+                continue
+            current_key = key
+            current_value_lines = [value.strip()]
+        else:
+            if current_key is not None:
+                current_value_lines.append(stripped)
+
+    _flush()
+    return fields
+
+
+def _designation_key_match(key: str) -> bool:
+    normalized = NON_ALNUM_RE.sub("", str(key or "").lower())
+    if not normalized:
+        return False
+    if any(bad in normalized for bad in DESIGNATION_KEY_EXCLUDES):
+        return False
+    return any(hint in normalized for hint in DESIGNATION_KEY_HINTS)
+
+
+def _extract_designations_from_wikitext(wikitext: str) -> list[str]:
+    infobox = _extract_infobox_block(wikitext)
+    if not infobox:
+        return []
+
+    values: list[str] = []
+    for key, raw_value in _parse_infobox_fields(infobox):
+        if not _designation_key_match(key):
+            continue
+        cleaned_value = _clean_wikitext_value(raw_value)
+        if not cleaned_value:
+            continue
+        parts = re.split(r"[;,•·\n]+", cleaned_value)
+        if not parts:
+            continue
+        for part in parts:
+            token = _clean_designation_token(part)
+            if not token:
+                continue
+            lowered = token.lower()
+            if lowered.startswith("http") or "://" in lowered:
+                continue
+            if lowered in {"none", "n/a", "unknown", "various", "multiple"}:
+                continue
+            if len(token) > 120:
+                continue
+            if not re.search(r"[A-Za-z0-9]", token):
+                continue
+            values.append(token)
+
+    return _dedupe_preserve_order(values)
+
+
+def _strip_parenthetical_suffix(text: str) -> str:
+    return re.sub(r"\s*\([^)]*\)\s*$", "", str(text or "").strip()).strip()
+
+
+def _extract_infobox_entries(wikitext: str) -> list[tuple[str, str, str]]:
+    infobox = _extract_infobox_block(wikitext)
+    if not infobox:
+        return []
+
+    entries: list[tuple[str, str, str]] = []
+    for key, raw_value in _parse_infobox_fields(infobox):
+        normalized_key = NON_ALNUM_RE.sub("", str(key or "").lower())
+        if not normalized_key:
+            continue
+        cleaned_value = _clean_wikitext_value(raw_value)
+        entries.append((normalized_key, cleaned_value, str(raw_value or "")))
+    return entries
+
+
+def _select_infobox_value(
+    entries: list[tuple[str, str, str]],
+    *,
+    includes: tuple[str, ...],
+    excludes: tuple[str, ...] = (),
+) -> str:
+    for normalized_key, cleaned_value, _raw_value in entries:
+        if any(bad in normalized_key for bad in excludes):
+            continue
+        if any(good in normalized_key for good in includes):
+            if cleaned_value:
+                return cleaned_value
+    return ""
+
+
+def _to_float_tokens(text: str) -> list[float]:
+    values: list[float] = []
+    for token in NUMBER_RE.findall(str(text or "")):
+        try:
+            values.append(float(token))
+        except ValueError:
+            continue
+    return values
+
+
+def _parse_ra_candidate(raw_value: str) -> float | None:
+    text = str(raw_value or "").replace("−", "-").replace("–", "-").strip()
+    if not text:
+        return None
+
+    lowered = text.lower()
+    values = _to_float_tokens(text)
+    if not values:
+        return None
+
+    if ("deg" in lowered or "°" in text or "degree" in lowered) and 0.0 <= values[0] <= 360.0:
+        return float(values[0] % 360.0)
+
+    if len(values) >= 3:
+        hours, minutes, seconds = abs(values[0]), abs(values[1]), abs(values[2])
+        deg = (hours + (minutes / 60.0) + (seconds / 3600.0)) * 15.0
+        if 0.0 <= deg <= 360.0:
+            return float(deg % 360.0)
+
+    if len(values) == 2:
+        hours, minutes = abs(values[0]), abs(values[1])
+        deg = (hours + (minutes / 60.0)) * 15.0
+        if 0.0 <= deg <= 360.0:
+            return float(deg % 360.0)
+
+    value = values[0]
+    if 0.0 <= value <= 24.0:
+        return float((value * 15.0) % 360.0)
+    if 0.0 <= value <= 360.0:
+        return float(value % 360.0)
+    return None
+
+
+def _parse_dec_candidate(raw_value: str) -> float | None:
+    text = str(raw_value or "").replace("−", "-").replace("–", "-").strip()
+    if not text:
+        return None
+
+    lowered = text.lower()
+    values = _to_float_tokens(text)
+    if not values:
+        return None
+
+    sign = -1.0 if text.lstrip().startswith("-") else 1.0
+    if values[0] < 0:
+        sign = -1.0
+
+    if ("deg" in lowered or "°" in text or "degree" in lowered) and len(values) >= 1:
+        degree = float(values[0])
+        if text.lstrip().startswith("+"):
+            degree = abs(degree)
+        if text.lstrip().startswith("-"):
+            degree = -abs(degree)
+        if -90.0 <= degree <= 90.0:
+            return degree
+
+    if len(values) >= 3:
+        degrees, minutes, seconds = abs(values[0]), abs(values[1]), abs(values[2])
+        dec = sign * (degrees + (minutes / 60.0) + (seconds / 3600.0))
+        if -90.0 <= dec <= 90.0:
+            return float(dec)
+
+    if len(values) == 2:
+        degrees, minutes = abs(values[0]), abs(values[1])
+        dec = sign * (degrees + (minutes / 60.0))
+        if -90.0 <= dec <= 90.0:
+            return float(dec)
+
+    dec = float(values[0])
+    if text.lstrip().startswith("+"):
+        dec = abs(dec)
+    elif text.lstrip().startswith("-"):
+        dec = -abs(dec)
+    if -90.0 <= dec <= 90.0:
+        return dec
+    return None
+
+
+def _is_ra_key(normalized_key: str) -> bool:
+    key = str(normalized_key or "")
+    if not key:
+        return False
+    if "radius" in key:
+        return False
+    if "image" in key or "caption" in key:
+        return False
+    return key == "ra" or key.startswith("ra") or "rightascension" in key
+
+
+def _is_dec_key(normalized_key: str) -> bool:
+    key = str(normalized_key or "")
+    if not key:
+        return False
+    if "image" in key or "caption" in key:
+        return False
+    return key == "dec" or key.startswith("dec") or "declination" in key
+
+
+def _extract_ra_dec_from_infobox(entries: list[tuple[str, str, str]]) -> tuple[float | None, float | None]:
+    ra_value: float | None = None
+    dec_value: float | None = None
+
+    for normalized_key, cleaned_value, raw_value in entries:
+        if ra_value is None and _is_ra_key(normalized_key):
+            ra_value = _parse_ra_candidate(raw_value) or _parse_ra_candidate(cleaned_value)
+        if dec_value is None and _is_dec_key(normalized_key):
+            dec_value = _parse_dec_candidate(raw_value) or _parse_dec_candidate(cleaned_value)
+        if ra_value is not None and dec_value is not None:
+            break
+
+    return ra_value, dec_value
+
+
+def _extract_common_name(
+    *,
+    entries: list[tuple[str, str, str]],
+    title: str,
+    primary_id: str,
+) -> str:
+    infobox_name = _select_infobox_value(
+        entries,
+        includes=("commonname", "propername", "name"),
+        excludes=(
+            "image",
+            "caption",
+            "catalog",
+            "designation",
+            "alias",
+            "othername",
+            "othernames",
+        ),
+    )
+    first_name = re.split(r"[;,•·\n]+", infobox_name)[0].strip() if infobox_name else ""
+
+    for candidate in [first_name, _strip_parenthetical_suffix(title)]:
+        text = str(candidate or "").strip()
+        if not text:
+            continue
+        if len(text) > 120:
+            continue
+        if _normalize_text(text) == _normalize_text(primary_id):
+            continue
+        return text
+    return ""
+
+
+def _extract_object_type(
+    *,
+    entries: list[tuple[str, str, str]],
+    short_description: str,
+    topic_label: str,
+) -> str:
+    from_infobox = _select_infobox_value(
+        entries,
+        includes=("objecttype", "classification", "type", "class"),
+        excludes=(
+            "spectral",
+            "variable",
+            "image",
+            "caption",
+            "name",
+            "distance",
+            "radius",
+            "magnitude",
+            "temperature",
+            "mass",
+        ),
+    )
+    if from_infobox:
+        token = re.split(r"[.;\n]+", from_infobox)[0].strip()
+        if token:
+            return token
+
+    fallback = str(short_description or "").strip()
+    if fallback:
+        token = re.split(r"[.;\n]+", fallback)[0].strip()
+        if token:
+            return token
+
+    if topic_label == "nebula":
+        return "Nebula"
+    if topic_label == "star":
+        return "Star"
+    return ""
+
+
+def _extract_constellation(entries: list[tuple[str, str, str]]) -> str:
+    value = _select_infobox_value(
+        entries,
+        includes=("constellation", "constell"),
+        excludes=("image", "caption"),
+    )
+    if not value:
+        return ""
+    token = re.split(r"[;,•·\n]+", value)[0].strip()
+    return token
+
+
+def _extract_emission_lines(entries: list[tuple[str, str, str]]) -> list[str]:
+    value = _select_infobox_value(
+        entries,
+        includes=("emissionline", "emissionlines", "spectralline", "spectrallines"),
+        excludes=("image", "caption"),
+    )
+    if not value:
+        return []
+
+    lines: list[str] = []
+    for part in re.split(r"[;,•·\n]+", value):
+        token = _clean_designation_token(part)
+        if not token:
+            continue
+        if len(token) > 40:
+            continue
+        if not re.search(r"[A-Za-z0-9]", token):
+            continue
+        lines.append(token)
+    return _dedupe_preserve_order(lines)
+
+
+def _identifier_catalog(primary_id: str) -> str:
+    cleaned = str(primary_id or "").strip()
+    if re.fullmatch(r"M\s*[0-9]+[A-Za-z]*", cleaned, flags=re.IGNORECASE):
+        return "M"
+    if re.fullmatch(r"NGC\s*[0-9]+(?:\s*[A-Za-z]+)?", cleaned, flags=re.IGNORECASE):
+        return "NGC"
+    if re.fullmatch(r"IC\s*[0-9]+(?:\s*[A-Za-z]+)?", cleaned, flags=re.IGNORECASE):
+        return "IC"
+    if re.fullmatch(r"Sh2-[0-9]+[A-Za-z]*", cleaned, flags=re.IGNORECASE):
+        return "SH2"
+    return ""
+
+
+def _canonicalize_requested_primary_id(raw_value: Any) -> str:
+    text = " ".join(str(raw_value or "").strip().split())
+    if not text:
+        return ""
+
+    text = _strip_name_prefix(text)
+
+    messier_match = re.fullmatch(r"(?:M|Messier)\s*0*([0-9]+)\s*([A-Za-z]*)", text, flags=re.IGNORECASE)
+    if messier_match:
+        number = str(int(messier_match.group(1)))
+        suffix = str(messier_match.group(2) or "").strip().upper()
+        return f"M{number}{suffix}" if suffix else f"M{number}"
+
+    ngc_match = re.fullmatch(r"NGC\s*0*([0-9]+)\s*([A-Za-z]*)", text, flags=re.IGNORECASE)
+    if ngc_match:
+        number = str(int(ngc_match.group(1)))
+        suffix = str(ngc_match.group(2) or "").strip().upper()
+        return f"NGC {number}" if not suffix else f"NGC {number} {suffix}"
+
+    ic_match = re.fullmatch(r"IC\s*0*([0-9]+)\s*([A-Za-z]*)", text, flags=re.IGNORECASE)
+    if ic_match:
+        number = str(int(ic_match.group(1)))
+        suffix = str(ic_match.group(2) or "").strip().upper()
+        return f"IC {number}" if not suffix else f"IC {number} {suffix}"
+
+    sh2_match = re.fullmatch(
+        r"(?:Sh2|Sh\s*2|Sharpless\s*2)[-\s]*0*([0-9]+)\s*([A-Za-z]*)",
+        text,
+        flags=re.IGNORECASE,
+    )
+    if sh2_match:
+        number = str(int(sh2_match.group(1)))
+        suffix = str(sh2_match.group(2) or "").strip().upper()
+        return f"Sh2-{number}{suffix}" if suffix else f"Sh2-{number}"
+
+    return text
+
+
+def _extract_catalog_id_candidates(text: str) -> list[tuple[int, str, str]]:
+    source = str(text or "")
+    matches: list[tuple[int, str, str]] = []
+
+    for match in re.finditer(r"\b(?:Messier|M)\s*0*([0-9]+)\s*([A-Za-z]*)\b", source, flags=re.IGNORECASE):
+        number = str(int(match.group(1)))
+        suffix = str(match.group(2) or "").strip()
+        ident = f"M{number}{suffix}" if suffix else f"M{number}"
+        matches.append((int(match.start()), ident, "M"))
+
+    for match in re.finditer(r"\bNGC\s*0*([0-9]+)\s*([A-Za-z]*)\b", source, flags=re.IGNORECASE):
+        number = str(int(match.group(1)))
+        suffix = str(match.group(2) or "").strip()
+        ident = f"NGC {number}" if not suffix else f"NGC {number} {suffix}"
+        matches.append((int(match.start()), ident, "NGC"))
+
+    for match in re.finditer(r"\bIC\s*0*([0-9]+)\s*([A-Za-z]*)\b", source, flags=re.IGNORECASE):
+        number = str(int(match.group(1)))
+        suffix = str(match.group(2) or "").strip()
+        ident = f"IC {number}" if not suffix else f"IC {number} {suffix}"
+        matches.append((int(match.start()), ident, "IC"))
+
+    for match in re.finditer(
+        r"\b(?:Sh2|Sh\s*2|Sharpless\s*2)[-\s]*0*([0-9]+)\s*([A-Za-z]*)\b",
+        source,
+        flags=re.IGNORECASE,
+    ):
+        number = str(int(match.group(1)))
+        suffix = str(match.group(2) or "").strip()
+        ident = f"Sh2-{number}{suffix}" if suffix else f"Sh2-{number}"
+        matches.append((int(match.start()), ident, "SH2"))
+
+    matches.sort(key=lambda item: item[0])
+    return matches
+
+
+def _extract_wikipedia_primary_catalog_reference(
+    *,
+    title: str,
+    aliases: list[str],
+    designations: list[str],
+) -> tuple[str, str]:
+    for candidate in [title, *aliases, *designations]:
+        parsed = _extract_catalog_id_candidates(candidate)
+        if parsed:
+            _position, ident, catalog = parsed[0]
+            return ident, catalog
+
+    fallback = _strip_parenthetical_suffix(title)
+    return fallback, _identifier_catalog(fallback)
+
+
+def _file_title_from_image_url(image_url: str) -> str:
+    parsed = urlparse(str(image_url or "").strip())
+    path = str(parsed.path or "")
+    if not path:
+        return ""
+    filename = unquote(path.rsplit("/", 1)[-1]).strip()
+    if not filename:
+        return ""
+    filename = re.sub(r"^[0-9]+px-", "", filename)
+    if not filename:
+        return ""
+    if filename.lower().startswith("file:"):
+        return filename
+    return f"File:{filename}"
+
+
+def _messier_num(primary_id: str) -> int | None:
+    match = re.fullmatch(r"M\s*([0-9]+)", str(primary_id).strip(), flags=re.IGNORECASE)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def _sharpless_parts(primary_id: str) -> tuple[str, str] | None:
+    match = re.fullmatch(r"Sh2-([0-9]+)([A-Za-z]*)", str(primary_id).strip(), flags=re.IGNORECASE)
+    if not match:
+        return None
+    number = str(int(match.group(1)))
+    suffix = str(match.group(2) or "").strip()
+    return number, suffix
+
+
+def _build_title_candidates(row: dict[str, Any]) -> list[str]:
+    primary_id = str(row.get("primary_id", "")).strip()
+    common_name = str(row.get("common_name", "")).strip()
+    aliases = _split_aliases(row.get("aliases", ""))
+    primary_id_clean = _strip_name_prefix(primary_id)
+    primary_id_variants = _name_variants(primary_id, include_name_prefixed_original=False)
+    common_name_variants = _name_variants(common_name, include_name_prefixed_original=False)
+    alias_variants = _with_name_prefix_variants(aliases, include_name_prefixed_original=False)
+
+    candidates: list[str] = []
+    messier_number = _messier_num(primary_id_clean)
+    sharpless = _sharpless_parts(primary_id_clean)
+
+    if messier_number is not None:
+        candidates.extend(
+            [
+                f"M {messier_number}",
+                f"Messier {messier_number}",
+                f"M{messier_number}",
+            ]
+        )
+
+    if sharpless is not None:
+        number, suffix = sharpless
+        suffix_text = suffix if suffix else ""
+        candidates.extend(
+            [
+                f"Sh2-{number}{suffix_text}",
+                f"Sh 2-{number}{suffix_text}",
+                f"Sharpless 2-{number}{suffix_text}",
+            ]
+        )
+
+    candidates.extend(primary_id_variants)
+    candidates.extend(common_name_variants)
+    candidates.extend(alias_variants[:10])
+    return _dedupe_preserve_order(candidates)
+
+
+def _build_search_queries(row: dict[str, Any], title_candidates: list[str]) -> list[str]:
+    primary_id = str(row.get("primary_id", "")).strip()
+    common_name = str(row.get("common_name", "")).strip()
+    primary_id_clean = _strip_name_prefix(primary_id)
+    primary_id_variants = _name_variants(primary_id, include_name_prefixed_original=False)
+    common_name_variants = _name_variants(common_name, include_name_prefixed_original=False)
+    queries: list[str] = []
+
+    messier_number = _messier_num(primary_id_clean)
+    sharpless = _sharpless_parts(primary_id_clean)
+    if messier_number is not None:
+        queries.extend(
+            [
+                f"M {messier_number}",
+                f"M{messier_number}",
+                f"Messier {messier_number}",
+            ]
+        )
+    if sharpless is not None:
+        number, suffix = sharpless
+        suffix_text = suffix if suffix else ""
+        queries.append(f"Sharpless 2-{number}{suffix_text}")
+        queries.append(f"Sh2-{number}{suffix_text}")
+
+    queries.extend(primary_id_variants)
+    queries.extend(common_name_variants)
+    queries.extend(title_candidates[:4])
+    return _dedupe_preserve_order(queries)
+
+
+def _build_identity_tokens(row: dict[str, Any]) -> list[str]:
+    tokens: list[str] = []
+    primary_id = str(row.get("primary_id", "")).strip()
+    common_name = str(row.get("common_name", "")).strip()
+    primary_id_clean = _strip_name_prefix(primary_id)
+    aliases = _split_aliases(row.get("aliases", ""))
+    primary_id_variants = _name_variants(primary_id, include_name_prefixed_original=False)
+    common_name_variants = _name_variants(common_name, include_name_prefixed_original=False)
+    alias_variants = _with_name_prefix_variants(aliases, include_name_prefixed_original=False)
+    tokens.extend(primary_id_variants)
+    tokens.extend(common_name_variants)
+    tokens.extend(alias_variants[:8])
+
+    messier_number = _messier_num(primary_id_clean)
+    if messier_number is not None:
+        tokens.extend([f"M{messier_number}", f"M {messier_number}", f"Messier {messier_number}"])
+
+    sharpless = _sharpless_parts(primary_id_clean)
+    if sharpless is not None:
+        number, suffix = sharpless
+        suffix_text = suffix if suffix else ""
+        tokens.extend(
+            [
+                f"Sh2-{number}{suffix_text}",
+                f"Sh 2-{number}{suffix_text}",
+                f"Sharpless 2-{number}{suffix_text}",
+            ]
+        )
+
+    normalized = [_normalize_text(token) for token in tokens]
+    return [token for token in _dedupe_preserve_order(normalized) if len(token) >= 2]
+
+
+def _score_search_result(result: dict[str, Any], identity_tokens: list[str]) -> int:
+    title = str(result.get("title", "")).strip()
+    snippet = _strip_html(str(result.get("snippet", "")))
+    content_norm = _normalize_text(f"{title} {snippet}")
+    title_norm = _normalize_text(title)
+
+    score = 0
+    if "disambiguation" in title.lower():
+        score -= 90
+
+    token_hits = 0
+    for token in identity_tokens:
+        if not token:
+            continue
+        if token in title_norm:
+            score += 35
+            token_hits += 1
+            continue
+        if token in content_norm:
+            score += 12
+            token_hits += 1
+    if token_hits == 0:
+        score -= 20
+
+    if _looks_astronomy(f"{title} {snippet}"):
+        score += 18
+    return score
+
+
+def _score_summary(title: str, extract: str, description: str, identity_tokens: list[str]) -> int:
+    title_norm = _normalize_text(title)
+    content_norm = _normalize_text(f"{title} {extract} {description}")
+    score = 0
+
+    if _looks_disambiguation(title, extract):
+        score -= 120
+
+    token_hits = 0
+    for token in identity_tokens:
+        if not token:
+            continue
+        if token in title_norm:
+            score += 40
+            token_hits += 1
+            continue
+        if token in content_norm:
+            score += 14
+            token_hits += 1
+    if token_hits == 0:
+        score -= 25
+
+    if _looks_astronomy(f"{title} {extract} {description}"):
+        score += 22
+
+    if extract.strip():
+        score += 10
+    return score
+
+
+@dataclass
+class WikipediaLookup:
+    title: str = ""
+    url: str = ""
+    description: str = ""
+    image_url: str = ""
+    image_attribution_url: str = ""
+    info_url: str = ""
+    designations: list[str] = None  # type: ignore[assignment]
+    aliases: list[str] = None  # type: ignore[assignment]
+    common_name: str = ""
+    object_type: str = ""
+    ra_deg: float | None = None
+    dec_deg: float | None = None
+    constellation: str = ""
+    emission_lines: list[str] = None  # type: ignore[assignment]
+    wikipedia_primary_id: str = ""
+    wikipedia_catalog: str = ""
+    match_method: str = "none"
+    match_score: int = -999
+    query_used: str = ""
+    requested_title: str = ""
+    topic_label: str = ""
+    redirected_from_query: bool = False
+    sentence_count: int = 0
+
+    def __post_init__(self) -> None:
+        if self.designations is None:
+            self.designations = []
+        if self.aliases is None:
+            self.aliases = []
+        if self.emission_lines is None:
+            self.emission_lines = []
+
+
+class WikipediaClient:
+    def __init__(
+        self,
+        *,
+        timeout_s: float,
+        requests_per_second: float,
+        cache_path: Path,
+        log: Callable[[int, str], None] | None = None,
+        user_agent: str = "deep-space-object-explorer-wiki-enrichment/1.0",
+    ) -> None:
+        self.timeout_s = timeout_s
+        self.min_interval_s = (1.0 / requests_per_second) if requests_per_second > 0 else 0.0
+        self._last_request_monotonic = 0.0
+        self._cache_path = cache_path
+        self._cache: dict[str, Any] = {}
+        self._user_agent = user_agent
+        self._log = log
+        self.cache_hits = 0
+        self.http_requests = 0
+        self.http_successes = 0
+        self.http_failures = 0
+        self.rate_limit_sleeps = 0
+        self._load_cache()
+
+    def _load_cache(self) -> None:
+        if not self._cache_path.exists():
+            self._cache = {}
+            return
+        try:
+            payload = json.loads(self._cache_path.read_text(encoding="utf-8"))
+            if isinstance(payload, dict):
+                self._cache = payload
+            else:
+                self._cache = {}
+        except (OSError, json.JSONDecodeError):
+            self._cache = {}
+
+    def flush_cache(self) -> None:
+        self._cache_path.parent.mkdir(parents=True, exist_ok=True)
+        self._cache_path.write_text(json.dumps(self._cache, ensure_ascii=True, sort_keys=True), encoding="utf-8")
+
+    def _rate_limit(self) -> None:
+        if self.min_interval_s <= 0:
+            return
+        now = time.monotonic()
+        wait_s = self.min_interval_s - (now - self._last_request_monotonic)
+        if wait_s > 0:
+            self.rate_limit_sleeps += 1
+            time.sleep(wait_s)
+        self._last_request_monotonic = time.monotonic()
+
+    def _request_json(
+        self,
+        *,
+        cache_key: str,
+        url: str,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        if cache_key in self._cache:
+            cached = self._cache[cache_key]
+            if isinstance(cached, dict):
+                self.cache_hits += 1
+                if self._log is not None:
+                    self._log(4, f"[http/cache-hit] {cache_key}")
+                return cached
+
+        full_url = url
+        if params:
+            query = urlencode(params, doseq=True)
+            separator = "&" if "?" in full_url else "?"
+            full_url = f"{full_url}{separator}{query}"
+
+        last_error: str | None = None
+        for attempt in range(3):
+            self._rate_limit()
+            try:
+                self.http_requests += 1
+                command = [
+                    "curl",
+                    "-sS",
+                    "-L",
+                    "--max-time",
+                    str(max(1, int(round(self.timeout_s)))),
+                    "-H",
+                    "Accept: application/json",
+                    "-H",
+                    f"User-Agent: {self._user_agent}",
+                    full_url,
+                ]
+                if self._log is not None:
+                    self._log(4, f"[http/request] attempt={attempt + 1} url={full_url}")
+                process = subprocess.run(
+                    command,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                if process.returncode != 0:
+                    raise RuntimeError(process.stderr.strip() or f"curl exit {process.returncode}")
+
+                payload = json.loads(process.stdout)
+                entry = {"ok": True, "payload": payload}
+                self._cache[cache_key] = entry
+                self.http_successes += 1
+                return entry
+            except Exception as error:
+                last_error = f"{error.__class__.__name__}: {str(error).strip()}"
+                self.http_failures += 1
+                if self._log is not None:
+                    self._log(3, f"[http/error] attempt={attempt + 1} cache_key={cache_key} error={last_error}")
+                if attempt < 2:
+                    time.sleep(0.4 * (2**attempt))
+                    continue
+
+        return {"ok": False, "error": str(last_error or "request failed")}
+
+    def request_stats(self) -> dict[str, int]:
+        return {
+            "cache_hits": int(self.cache_hits),
+            "http_requests": int(self.http_requests),
+            "http_successes": int(self.http_successes),
+            "http_failures": int(self.http_failures),
+            "rate_limit_sleeps": int(self.rate_limit_sleeps),
+        }
+
+    def summary(self, title: str) -> dict[str, Any] | None:
+        normalized_title = str(title or "").strip()
+        if not normalized_title:
+            return None
+        encoded = quote(normalized_title.replace(" ", "_"), safe="")
+        url = WIKIPEDIA_SUMMARY_URL.format(title=encoded)
+        cache_key = f"summary::{normalized_title.lower()}"
+        response = self._request_json(cache_key=cache_key, url=url)
+        if not response.get("ok"):
+            return None
+        payload = response.get("payload")
+        if not isinstance(payload, dict):
+            return None
+        return payload
+
+    def search(self, query: str, limit: int = 7) -> list[dict[str, Any]]:
+        query_text = str(query or "").strip()
+        if not query_text:
+            return []
+
+        params = {
+            "action": "query",
+            "format": "json",
+            "list": "search",
+            "srsearch": query_text,
+            "srlimit": int(limit),
+            "utf8": "1",
+            "srprop": "snippet",
+        }
+        cache_key = f"search::{query_text.lower()}::{limit}"
+        response = self._request_json(cache_key=cache_key, url=WIKIPEDIA_API_URL, params=params)
+        if not response.get("ok"):
+            return []
+        payload = response.get("payload")
+        if not isinstance(payload, dict):
+            return []
+        search_results = payload.get("query", {}).get("search", [])
+        if not isinstance(search_results, list):
+            return []
+        return [item for item in search_results if isinstance(item, dict)]
+
+    def intro_extract(self, title: str) -> str:
+        normalized_title = str(title or "").strip()
+        if not normalized_title:
+            return ""
+
+        params = {
+            "action": "query",
+            "format": "json",
+            "formatversion": 2,
+            "redirects": 1,
+            "prop": "extracts",
+            "exintro": 1,
+            "explaintext": 1,
+            "titles": normalized_title,
+        }
+        cache_key = f"extract::{normalized_title.lower()}"
+        response = self._request_json(cache_key=cache_key, url=WIKIPEDIA_API_URL, params=params)
+        if not response.get("ok"):
+            return ""
+        payload = response.get("payload")
+        if not isinstance(payload, dict):
+            return ""
+        pages = payload.get("query", {}).get("pages", [])
+        if not isinstance(pages, list) or not pages:
+            return ""
+        page = pages[0]
+        if not isinstance(page, dict):
+            return ""
+        return str(page.get("extract", "")).strip()
+
+    def page_image(self, title: str) -> str:
+        details = self.page_image_details(title)
+        return str(details.get("image_url", "")).strip()
+
+    def image_file_description_url(self, file_title: str) -> str:
+        normalized_file = str(file_title or "").strip()
+        if not normalized_file:
+            return ""
+        if not normalized_file.lower().startswith("file:"):
+            normalized_file = f"File:{normalized_file}"
+
+        params = {
+            "action": "query",
+            "format": "json",
+            "formatversion": 2,
+            "prop": "imageinfo",
+            "iiprop": "url",
+            "titles": normalized_file,
+        }
+        cache_key = f"imageinfo::{normalized_file.lower()}"
+        response = self._request_json(cache_key=cache_key, url=WIKIPEDIA_API_URL, params=params)
+        if not response.get("ok"):
+            return ""
+        payload = response.get("payload")
+        if not isinstance(payload, dict):
+            return ""
+        pages = payload.get("query", {}).get("pages", [])
+        if not isinstance(pages, list) or not pages:
+            return ""
+        page = pages[0]
+        if not isinstance(page, dict):
+            return ""
+        imageinfo = page.get("imageinfo", [])
+        if not isinstance(imageinfo, list) or not imageinfo:
+            return ""
+        info = imageinfo[0]
+        if not isinstance(info, dict):
+            return ""
+        description_url = str(info.get("descriptionurl", "")).strip()
+        if description_url:
+            return description_url
+        return str(info.get("url", "")).strip()
+
+    def page_image_details(self, title: str) -> dict[str, str]:
+        normalized_title = str(title or "").strip()
+        if not normalized_title:
+            return {"image_url": "", "file_title": "", "attribution_url": ""}
+        params = {
+            "action": "query",
+            "format": "json",
+            "formatversion": 2,
+            "redirects": 1,
+            "prop": "pageimages",
+            "piprop": "name|original",
+            "titles": normalized_title,
+        }
+        cache_key = f"pageimage_details::{normalized_title.lower()}"
+        response = self._request_json(cache_key=cache_key, url=WIKIPEDIA_API_URL, params=params)
+        if not response.get("ok"):
+            return {"image_url": "", "file_title": "", "attribution_url": ""}
+        payload = response.get("payload")
+        if not isinstance(payload, dict):
+            return {"image_url": "", "file_title": "", "attribution_url": ""}
+        pages = payload.get("query", {}).get("pages", [])
+        if not isinstance(pages, list) or not pages:
+            return {"image_url": "", "file_title": "", "attribution_url": ""}
+        page = pages[0]
+        if not isinstance(page, dict):
+            return {"image_url": "", "file_title": "", "attribution_url": ""}
+        pageimage = str(page.get("pageimage", "")).strip()
+        file_title = f"File:{pageimage}" if pageimage else ""
+        original = page.get("original")
+        image_url = ""
+        if not isinstance(original, dict):
+            image_url = ""
+        else:
+            image_url = str(original.get("source", "")).strip()
+        attribution_url = self.image_file_description_url(file_title) if file_title else ""
+        return {
+            "image_url": image_url,
+            "file_title": file_title,
+            "attribution_url": attribution_url,
+        }
+
+    def wikitext(self, title: str) -> str:
+        normalized_title = str(title or "").strip()
+        if not normalized_title:
+            return ""
+        params = {
+            "action": "parse",
+            "format": "json",
+            "formatversion": 2,
+            "redirects": 1,
+            "prop": "wikitext",
+            "page": normalized_title,
+        }
+        cache_key = f"wikitext::{normalized_title.lower()}"
+        response = self._request_json(cache_key=cache_key, url=WIKIPEDIA_API_URL, params=params)
+        if not response.get("ok"):
+            return ""
+        payload = response.get("payload")
+        if not isinstance(payload, dict):
+            return ""
+        parsed = payload.get("parse")
+        if not isinstance(parsed, dict):
+            return ""
+        return str(parsed.get("wikitext", "")).strip()
+
+
+def _summary_to_url(summary_payload: dict[str, Any], fallback_title: str) -> str:
+    content_urls = summary_payload.get("content_urls")
+    if isinstance(content_urls, dict):
+        desktop = content_urls.get("desktop")
+        if isinstance(desktop, dict):
+            page_url = str(desktop.get("page", "")).strip()
+            if page_url:
+                return page_url
+    safe_title = quote(str(fallback_title).replace(" ", "_"), safe="")
+    return f"https://en.wikipedia.org/wiki/{safe_title}"
+
+
+def _summary_to_image(summary_payload: dict[str, Any]) -> str:
+    original = summary_payload.get("originalimage")
+    if isinstance(original, dict):
+        source = str(original.get("source", "")).strip()
+        if source:
+            return source
+    thumbnail = summary_payload.get("thumbnail")
+    if isinstance(thumbnail, dict):
+        source = str(thumbnail.get("source", "")).strip()
+        if source:
+            return source
+    return ""
+
+
+def _resolve_wikipedia_page(
+    row: dict[str, Any],
+    client: WikipediaClient,
+    *,
+    log: Callable[[int, str], None] | None = None,
+) -> WikipediaLookup:
+    def _log(level: int, message: str) -> None:
+        if log is not None:
+            log(level, message)
+
+    identity_tokens = _build_identity_tokens(row)
+    title_candidates = _build_title_candidates(row)
+    search_queries = _build_search_queries(row, title_candidates)
+    target_prefers_nebula = _row_prefers_nebula(row)
+    messier_number = _messier_num(_strip_name_prefix(str(row.get("primary_id", "")).strip()))
+    _log(3, f"[resolver] identity_tokens={identity_tokens}")
+    _log(3, f"[resolver] title_candidates={title_candidates}")
+    _log(3, f"[resolver] search_queries={search_queries}")
+    _log(3, f"[resolver] target_prefers_nebula={target_prefers_nebula}")
+
+    best = WikipediaLookup(match_method="none", match_score=-999)
+    best_nebula = WikipediaLookup(match_method="none", match_score=-999)
+    checked_titles: set[str] = set()
+
+    # First pass: direct title attempts for high-precision matches.
+    for idx, candidate_title in enumerate(title_candidates[:6]):
+        candidate_title = str(candidate_title).strip()
+        if not candidate_title:
+            continue
+        normalized = candidate_title.lower()
+        if normalized in checked_titles:
+            continue
+        checked_titles.add(normalized)
+        _log(3, f"[resolver/direct] candidate='{candidate_title}'")
+
+        summary = client.summary(candidate_title)
+        if not summary:
+            _log(3, "[resolver/direct] no summary payload")
+            continue
+
+        title = str(summary.get("title", "")).strip() or candidate_title
+        extract = str(summary.get("extract", "")).strip()
+        short_description = str(summary.get("description", "")).strip()
+        topic_label = _page_topic_label(title, extract, short_description)
+        redirected = _normalize_text(title) != _normalize_text(candidate_title)
+        score = _score_summary(title, extract, short_description, identity_tokens) + 15 - (idx * 2)
+        _log(
+            3,
+            f"[resolver/direct] resolved_title='{title}' score={score} topic={topic_label} "
+            f"redirected={redirected} desc='{_truncate(short_description, 80)}'",
+        )
+        candidate_lookup = WikipediaLookup(
+            title=title,
+            url=_summary_to_url(summary, title),
+            description="",
+            image_url="",
+            designations=[],
+            match_method="direct_title",
+            match_score=score,
+            query_used=candidate_title,
+            requested_title=candidate_title,
+            topic_label=topic_label,
+            redirected_from_query=redirected,
+            sentence_count=0,
+        )
+
+        if score > best.match_score:
+            best = candidate_lookup
+            _log(3, f"[resolver/direct] best_updated title='{title}' score={score}")
+        if topic_label == "nebula" and score > best_nebula.match_score:
+            best_nebula = candidate_lookup
+            _log(3, f"[resolver/direct] nebula_best_updated title='{title}' score={score}")
+
+        if (
+            score >= 80
+            and not _looks_disambiguation(title, extract)
+            and (not target_prefers_nebula or topic_label == "nebula")
+        ):
+            _log(3, f"[resolver/direct] early_accept title='{title}' score={score}")
+            break
+
+    # Second pass: search fallback.
+    needs_search = best.match_score < 80
+    if target_prefers_nebula and best_nebula.match_score < 80:
+        needs_search = True
+
+    if needs_search:
+        for query in search_queries[:5]:
+            _log(3, f"[resolver/search] query='{query}'")
+            results = client.search(query, limit=8)
+            if not results:
+                _log(3, "[resolver/search] no results")
+                continue
+
+            ranked = sorted(
+                results,
+                key=lambda result: _score_search_result(result, identity_tokens),
+                reverse=True,
+            )
+            top_result = ranked[0]
+            top_title = str(top_result.get("title", "")).strip()
+            if not top_title:
+                _log(3, "[resolver/search] top result missing title")
+                continue
+            normalized_top = top_title.lower()
+            if normalized_top in checked_titles:
+                _log(3, f"[resolver/search] top title already checked '{top_title}'")
+                continue
+            checked_titles.add(normalized_top)
+            _log(3, f"[resolver/search] top_title='{top_title}'")
+
+            summary = client.summary(top_title)
+            if not summary:
+                _log(3, "[resolver/search] summary missing for top title")
+                continue
+
+            query_used_for_candidate = query
+            title = str(summary.get("title", "")).strip() or top_title
+            extract = str(summary.get("extract", "")).strip()
+            short_description = str(summary.get("description", "")).strip()
+            topic_label = _page_topic_label(title, extract, short_description)
+            redirected = _normalize_text(title) != _normalize_text(top_title)
+
+            # For Messier shorthand queries like "M 31", retry with "Messier 31"
+            # when the shorthand result does not appear to be a DSO page.
+            if _is_m_shorthand_query(query, messier_number) and not _looks_messier_object_page(
+                title,
+                extract,
+                short_description,
+            ):
+                fallback_query = f"Messier {messier_number}"
+                _log(
+                    3,
+                    f"[resolver/search] shorthand_query='{query}' produced non-dso page; "
+                    f"trying fallback='{fallback_query}'",
+                )
+                fallback_results = client.search(fallback_query, limit=8)
+                if fallback_results:
+                    fallback_ranked = sorted(
+                        fallback_results,
+                        key=lambda result: _score_search_result(result, identity_tokens),
+                        reverse=True,
+                    )
+                    fallback_top = fallback_ranked[0]
+                    fallback_title = str(fallback_top.get("title", "")).strip()
+                    if fallback_title:
+                        fallback_norm = fallback_title.lower()
+                        if fallback_norm not in checked_titles:
+                            checked_titles.add(fallback_norm)
+                        fallback_summary = client.summary(fallback_title)
+                        if fallback_summary:
+                            top_result = fallback_top
+                            top_title = fallback_title
+                            summary = fallback_summary
+                            query_used_for_candidate = fallback_query
+                            title = str(summary.get("title", "")).strip() or top_title
+                            extract = str(summary.get("extract", "")).strip()
+                            short_description = str(summary.get("description", "")).strip()
+                            topic_label = _page_topic_label(title, extract, short_description)
+                            redirected = _normalize_text(title) != _normalize_text(top_title)
+                            _log(
+                                3,
+                                f"[resolver/search] fallback resolved_title='{title}' topic={topic_label}",
+                            )
+
+            score = _score_summary(title, extract, short_description, identity_tokens)
+            score += _score_search_result(top_result, identity_tokens)
+            _log(
+                3,
+                f"[resolver/search] resolved_title='{title}' score={score} topic={topic_label} "
+                f"redirected={redirected} desc='{_truncate(short_description, 80)}'",
+            )
+            candidate_lookup = WikipediaLookup(
+                title=title,
+                url=_summary_to_url(summary, title),
+                description="",
+                image_url="",
+                designations=[],
+                match_method="search",
+                match_score=score,
+                query_used=query_used_for_candidate,
+                requested_title=top_title,
+                topic_label=topic_label,
+                redirected_from_query=redirected,
+                sentence_count=0,
+            )
+
+            if score > best.match_score:
+                best = candidate_lookup
+                _log(3, f"[resolver/search] best_updated title='{title}' score={score}")
+            if topic_label == "nebula" and score > best_nebula.match_score:
+                best_nebula = candidate_lookup
+                _log(3, f"[resolver/search] nebula_best_updated title='{title}' score={score}")
+
+            if (
+                score >= 85
+                and not _looks_disambiguation(title, extract)
+                and (not target_prefers_nebula or topic_label == "nebula")
+            ):
+                _log(3, f"[resolver/search] early_accept title='{title}' score={score}")
+                break
+
+    selected = best
+    if target_prefers_nebula and best_nebula.match_score >= 30:
+        selected = best_nebula
+        if _normalize_text(selected.title) != _normalize_text(best.title):
+            _log(
+                2,
+                f"[resolver/select] preferring nebula page title='{selected.title}' "
+                f"over title='{best.title}'",
+            )
+
+    if selected.match_score < 40 or not selected.title:
+        _log(2, f"[resolver/final] no match score={selected.match_score}")
+        return WikipediaLookup(match_method="no_match", match_score=selected.match_score)
+
+    chosen_summary = client.summary(selected.title) or {}
+    chosen_extract = str(chosen_summary.get("extract", "")).strip()
+    chosen_short_desc = str(chosen_summary.get("description", "")).strip()
+    info_url = selected.url or _summary_to_url(chosen_summary, selected.title)
+    intro_extract = client.intro_extract(selected.title) if len(_sentence_list(chosen_extract)) < 3 else ""
+    description = _description_3_to_4_sentences(chosen_extract, intro_extract)
+
+    image_url = _summary_to_image(chosen_summary)
+    image_details = client.page_image_details(selected.title)
+    if not image_url:
+        image_url = str(image_details.get("image_url", "")).strip()
+    image_file_title = str(image_details.get("file_title", "")).strip()
+    image_attribution_url = str(image_details.get("attribution_url", "")).strip()
+    if not image_file_title and image_url:
+        image_file_title = _file_title_from_image_url(image_url)
+    if not image_attribution_url and image_file_title:
+        image_attribution_url = client.image_file_description_url(image_file_title)
+    if not image_attribution_url:
+        image_attribution_url = info_url
+
+    wikitext = client.wikitext(selected.title)
+    designations = _extract_designations_from_wikitext(wikitext)
+    infobox_entries = _extract_infobox_entries(wikitext)
+    searched_name = _strip_name_prefix(
+        selected.requested_title or selected.query_used or str(row.get("primary_id", "")).strip()
+    )
+    if (
+        target_prefers_nebula
+        and selected.topic_label == "star"
+        and selected.redirected_from_query
+        and searched_name
+        and _normalize_text(searched_name) != _normalize_text(selected.title)
+    ):
+        description = _append_sentence_if_missing(
+            description,
+            f"{selected.title} is an object related to {searched_name}",
+        )
+        designations = _dedupe_preserve_order([selected.title, *designations])
+        _log(
+            2,
+            f"[resolver/final] applied star-redirect relation note redirected='{selected.title}' "
+            f"searched='{searched_name}'",
+        )
+
+    catalog_primary_id = str(row.get("primary_id", "")).strip()
+    common_name = _extract_common_name(
+        entries=infobox_entries,
+        title=selected.title,
+        primary_id=catalog_primary_id,
+    )
+    object_type = _extract_object_type(
+        entries=infobox_entries,
+        short_description=chosen_short_desc,
+        topic_label=selected.topic_label,
+    )
+    ra_deg, dec_deg = _extract_ra_dec_from_infobox(infobox_entries)
+    constellation = _extract_constellation(infobox_entries)
+    emission_lines = _extract_emission_lines(infobox_entries)
+    aliases = _dedupe_preserve_order([*designations, common_name, _strip_parenthetical_suffix(selected.title)])
+    aliases = [alias for alias in aliases if _normalize_text(alias) != _normalize_text(catalog_primary_id)]
+    wikipedia_primary_id, wikipedia_catalog = _extract_wikipedia_primary_catalog_reference(
+        title=selected.title,
+        aliases=aliases,
+        designations=designations,
+    )
+
+    sentence_count = len(_sentence_list(description))
+    _log(
+        2,
+        f"[resolver/final] title='{selected.title}' method={selected.match_method} score={selected.match_score} "
+        f"topic={selected.topic_label} redirected={selected.redirected_from_query} "
+        f"sentences={sentence_count} image={'yes' if bool(image_url) else 'no'} "
+        f"designations={len(designations)} aliases={len(aliases)} "
+        f"short_desc='{_truncate(chosen_short_desc, 80)}'",
+    )
+
+    return WikipediaLookup(
+        title=selected.title,
+        url=info_url,
+        info_url=info_url,
+        description=description,
+        image_url=image_url,
+        image_attribution_url=image_attribution_url,
+        designations=designations,
+        aliases=aliases,
+        common_name=common_name,
+        object_type=object_type,
+        ra_deg=ra_deg,
+        dec_deg=dec_deg,
+        constellation=constellation,
+        emission_lines=emission_lines,
+        wikipedia_primary_id=wikipedia_primary_id,
+        wikipedia_catalog=wikipedia_catalog,
+        match_method=selected.match_method,
+        match_score=selected.match_score,
+        query_used=selected.query_used,
+        requested_title=selected.requested_title,
+        topic_label=selected.topic_label,
+        redirected_from_query=selected.redirected_from_query,
+        sentence_count=sentence_count,
+    )
+
+
+def _load_targets(
+    *,
+    catalog_path: Path,
+    include_catalogs: tuple[str, ...],
+    include_groups: tuple[str, ...],
+    include_primary_ids: tuple[str, ...],
+) -> pd.DataFrame:
+    frame = pd.read_parquet(catalog_path)
+    if "primary_id" not in frame.columns:
+        raise ValueError("Catalog is missing required column: primary_id")
+
+    catalogs_upper = {value.strip().upper() for value in include_catalogs if value.strip()}
+    groups_lower = {value.strip().lower() for value in include_groups if value.strip()}
+    requested_primary_ids = _dedupe_preserve_order(
+        [
+            _canonicalize_requested_primary_id(value)
+            for value in include_primary_ids
+            if str(value or "").strip()
+        ]
+    )
+    requested_primary_keys = {_normalize_text(value) for value in requested_primary_ids if value}
+
+    catalog_col = frame.get("catalog", pd.Series("", index=frame.index)).fillna("").astype(str).str.upper().str.strip()
+    group_col = (
+        frame.get("object_type_group", pd.Series("", index=frame.index))
+        .fillna("")
+        .astype(str)
+        .str.lower()
+        .str.strip()
+    )
+
+    base_mask = catalog_col.isin(catalogs_upper) | group_col.isin(groups_lower)
+    if requested_primary_keys:
+        primary_key_col = frame.get("primary_id", pd.Series("", index=frame.index)).fillna("").astype(str).map(
+            lambda value: _normalize_text(" ".join(str(value or "").strip().split()))
+        )
+        base_mask = base_mask | primary_key_col.isin(requested_primary_keys)
+
+    selected = frame.loc[base_mask].copy()
+
+    if requested_primary_ids:
+        selected_key_set = {
+            _normalize_text(" ".join(str(value or "").strip().split()))
+            for value in selected.get("primary_id", pd.Series("", index=selected.index)).tolist()
+            if str(value or "").strip()
+        }
+
+        synthetic_records: list[dict[str, Any]] = []
+        for requested_primary_id in requested_primary_ids:
+            normalized_requested = _normalize_text(requested_primary_id)
+            if not normalized_requested:
+                continue
+            if normalized_requested in selected_key_set:
+                continue
+            selected_key_set.add(normalized_requested)
+
+            synthetic: dict[str, Any] = {}
+            for column in frame.columns:
+                if pd.api.types.is_numeric_dtype(frame[column].dtype):
+                    synthetic[column] = float("nan")
+                else:
+                    synthetic[column] = ""
+
+            synthetic["primary_id"] = requested_primary_id
+            synthetic["catalog"] = _identifier_catalog(requested_primary_id) or "WIKI"
+            synthetic["common_name"] = ""
+            synthetic["object_type_group"] = ""
+            synthetic["aliases"] = ""
+            synthetic_records.append(synthetic)
+
+        if synthetic_records:
+            selected = pd.concat(
+                [selected, pd.DataFrame.from_records(synthetic_records, columns=list(frame.columns))],
+                ignore_index=True,
+                sort=False,
+            )
+
+    selected["primary_id"] = selected["primary_id"].fillna("").astype(str).str.strip()
+    selected = selected[selected["primary_id"] != ""]
+    selected = selected.drop_duplicates(subset=["primary_id"], keep="first")
+    selected = selected.sort_values(by=["catalog", "primary_id"], ascending=[True, True]).reset_index(drop=True)
+    return selected
+
+
+def _parse_csv_list(raw: str) -> tuple[str, ...]:
+    parts = [item.strip() for item in str(raw or "").split(",")]
+    return tuple([item for item in parts if item])
+
+
+EXPECTED_CATALOG_ENRICHMENT_KEYS = (
+    "common_name",
+    "object_type",
+    "ra_deg",
+    "dec_deg",
+    "constellation",
+    "aliases",
+    "image_url",
+    "image_attribution_url",
+    "description",
+    "info_url",
+    "emission_lines",
+    "wikipedia_primary_id",
+    "wikipedia_catalog",
+)
+
+
+def _has_catalog_enrichment(row: dict[str, Any]) -> bool:
+    payload = row.get("catalog_enrichment")
+    if not isinstance(payload, dict):
+        return False
+    return all(key in payload for key in EXPECTED_CATALOG_ENRICHMENT_KEYS)
+
+
+def _make_logger(verbosity: int) -> Callable[[int, str], None]:
+    def _log(level: int, message: str) -> None:
+        if verbosity >= level:
+            print(message, flush=True)
+
+    return _log
+
+
+def _load_existing_rows(
+    output_path: Path,
+    *,
+    log: Callable[[int, str], None],
+) -> tuple[dict[str, dict[str, Any]], dict[str, int]]:
+    if not output_path.exists():
+        return {}, {
+            "loaded_rows": 0,
+            "invalid_rows": 0,
+            "duplicate_primary_ids": 0,
+        }
+
+    try:
+        payload = json.loads(output_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        log(1, f"[resume] unable to parse existing output '{output_path}': {error}")
+        return {}, {
+            "loaded_rows": 0,
+            "invalid_rows": 0,
+            "duplicate_primary_ids": 0,
+        }
+
+    if not isinstance(payload, dict):
+        log(1, f"[resume] existing output is not a JSON object: {output_path}")
+        return {}, {
+            "loaded_rows": 0,
+            "invalid_rows": 0,
+            "duplicate_primary_ids": 0,
+        }
+
+    source_rows = payload.get("targets", [])
+    if not isinstance(source_rows, list):
+        log(1, f"[resume] existing output has no 'targets' array: {output_path}")
+        return {}, {
+            "loaded_rows": 0,
+            "invalid_rows": 0,
+            "duplicate_primary_ids": 0,
+        }
+
+    loaded: dict[str, dict[str, Any]] = {}
+    invalid_rows = 0
+    duplicate_primary_ids = 0
+    for row in source_rows:
+        if not isinstance(row, dict):
+            invalid_rows += 1
+            continue
+        primary_id = str(row.get("primary_id", "")).strip()
+        if not primary_id:
+            invalid_rows += 1
+            continue
+        if primary_id in loaded:
+            duplicate_primary_ids += 1
+            continue
+        loaded[primary_id] = row
+
+    return loaded, {
+        "loaded_rows": int(len(loaded)),
+        "invalid_rows": int(invalid_rows),
+        "duplicate_primary_ids": int(duplicate_primary_ids),
+    }
+
+
+def _compute_row_stats(rows: list[dict[str, Any]]) -> dict[str, int]:
+    matched = 0
+    no_match = 0
+    with_image = 0
+    with_designations = 0
+    with_3plus_sentences = 0
+    unknown_status = 0
+
+    for row in rows:
+        status = str(row.get("status", "")).strip().lower()
+        if status == "matched":
+            matched += 1
+        elif status == "no_match":
+            no_match += 1
+        else:
+            unknown_status += 1
+
+        if str(row.get("image_url", "")).strip():
+            with_image += 1
+
+        designations = row.get("designations", [])
+        if isinstance(designations, list) and len(designations) > 0:
+            with_designations += 1
+
+        sentence_count_raw = row.get("description_sentence_count", 0)
+        try:
+            sentence_count = int(sentence_count_raw)
+        except (TypeError, ValueError):
+            sentence_count = 0
+        if sentence_count >= 3:
+            with_3plus_sentences += 1
+
+    return {
+        "matched": int(matched),
+        "no_match": int(no_match),
+        "unknown_status": int(unknown_status),
+        "with_image": int(with_image),
+        "with_designations": int(with_designations),
+        "with_3plus_sentence_description": int(with_3plus_sentences),
+    }
+
+
+def _build_payload(
+    *,
+    generated_at_utc: str,
+    catalog_path: Path,
+    include_catalogs: tuple[str, ...],
+    include_groups: tuple[str, ...],
+    include_primary_ids: tuple[str, ...],
+    target_count: int,
+    rows: list[dict[str, Any]],
+    stats: dict[str, int],
+    resume_enabled: bool,
+    resume_retry_no_match: bool,
+    resume_rows_reused: int,
+    rows_processed_this_run: int,
+    duration_seconds: float,
+    http_stats: dict[str, int],
+    verbosity: int,
+) -> dict[str, Any]:
+    return {
+        "generated_at_utc": generated_at_utc,
+        "catalog_path": str(catalog_path),
+        "selection": {
+            "catalogs": list(include_catalogs),
+            "object_type_groups": list(include_groups),
+            "primary_ids": list(include_primary_ids),
+            "target_count": int(target_count),
+        },
+        "run": {
+            "resume_enabled": bool(resume_enabled),
+            "resume_retry_no_match": bool(resume_retry_no_match),
+            "resume_rows_reused": int(resume_rows_reused),
+            "rows_processed_this_run": int(rows_processed_this_run),
+            "duration_seconds": round(float(duration_seconds), 3),
+            "verbosity": int(verbosity),
+        },
+        "stats": stats,
+        "http": http_stats,
+        "targets": rows,
+    }
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build standalone Wikipedia enrichment JSON for selected catalog targets.",
+    )
+    parser.add_argument(
+        "--catalog-path",
+        type=Path,
+        default=Path("data/dso_catalog_cache.parquet"),
+        help="Input catalog parquet path.",
+    )
+    parser.add_argument(
+        "--output-path",
+        type=Path,
+        default=Path("data/wikipedia_catalog_enrichment.json"),
+        help="Output JSON path.",
+    )
+    parser.add_argument(
+        "--cache-path",
+        type=Path,
+        default=Path("data/wikipedia_api_cache.json"),
+        help="HTTP response cache JSON path.",
+    )
+    parser.add_argument(
+        "--include-catalogs",
+        type=str,
+        default=",".join(DEFAULT_INCLUDE_CATALOGS),
+        help="Comma-separated catalog filters (upper/lower insensitive).",
+    )
+    parser.add_argument(
+        "--include-groups",
+        type=str,
+        default=",".join(DEFAULT_INCLUDE_GROUPS),
+        help="Comma-separated object_type_group filters (upper/lower insensitive).",
+    )
+    parser.add_argument(
+        "--include-primary-ids",
+        type=str,
+        default="",
+        help=(
+            "Comma-separated primary IDs to include in addition to catalog/group "
+            "selection (case-insensitive)."
+        ),
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Optional max target count (0 means no limit).",
+    )
+    parser.add_argument(
+        "--requests-per-second",
+        type=float,
+        default=4.0,
+        help="Wikipedia API request rate cap.",
+    )
+    parser.add_argument(
+        "--timeout-s",
+        type=float,
+        default=10.0,
+        help="HTTP timeout in seconds.",
+    )
+    parser.add_argument(
+        "--resume",
+        dest="resume",
+        action="store_true",
+        default=True,
+        help="Resume from existing output JSON when present (default: enabled).",
+    )
+    parser.add_argument(
+        "--no-resume",
+        dest="resume",
+        action="store_false",
+        help="Disable resume mode and rebuild output from scratch.",
+    )
+    parser.add_argument(
+        "--retry-no-match",
+        action="store_true",
+        help="When resuming, reprocess rows previously marked as no_match.",
+    )
+    parser.add_argument(
+        "--checkpoint-every",
+        type=int,
+        default=25,
+        help="Write intermediate output and flush API cache every N newly processed rows (0 disables).",
+    )
+    parser.add_argument(
+        "--progress-every",
+        type=int,
+        default=10,
+        help="Print rollup progress every N targets.",
+    )
+    parser.add_argument(
+        "--verbosity",
+        type=int,
+        default=2,
+        help=(
+            "Logging verbosity (0=quiet, 1=milestones, 2=per-target, "
+            "3=resolver internals, 4=HTTP/cache internals)."
+        ),
+    )
+    return parser
+
+
+def main() -> None:
+    args = _build_arg_parser().parse_args()
+    run_started = time.monotonic()
+    verbosity = max(0, int(args.verbosity))
+    log = _make_logger(verbosity)
+
+    include_catalogs = _parse_csv_list(args.include_catalogs)
+    include_groups = _parse_csv_list(args.include_groups)
+    include_primary_ids = _parse_csv_list(args.include_primary_ids)
+
+    log(1, "[startup] wikipedia enrichment run")
+    log(
+        1,
+        "[startup] config "
+        f"catalog_path={args.catalog_path} output_path={args.output_path} cache_path={args.cache_path} "
+        f"resume={args.resume} retry_no_match={args.retry_no_match} "
+        f"limit={args.limit} rps={args.requests_per_second} timeout_s={args.timeout_s} "
+        f"checkpoint_every={args.checkpoint_every} progress_every={args.progress_every} verbosity={verbosity} "
+        f"include_primary_ids={len(include_primary_ids)}",
+    )
+
+    targets = _load_targets(
+        catalog_path=args.catalog_path,
+        include_catalogs=include_catalogs,
+        include_groups=include_groups,
+        include_primary_ids=include_primary_ids,
+    )
+    if args.limit and args.limit > 0:
+        targets = targets.head(int(args.limit)).copy()
+        log(1, f"[startup] applied limit: {args.limit}")
+
+    resume_rows_by_id: dict[str, dict[str, Any]] = {}
+    resume_meta: dict[str, int] = {
+        "loaded_rows": 0,
+        "invalid_rows": 0,
+        "duplicate_primary_ids": 0,
+    }
+    if args.resume:
+        resume_rows_by_id, resume_meta = _load_existing_rows(args.output_path, log=log)
+        log(
+            1,
+            "[resume] loaded "
+            f"rows={resume_meta['loaded_rows']} invalid={resume_meta['invalid_rows']} "
+            f"duplicates={resume_meta['duplicate_primary_ids']}",
+        )
+    else:
+        log(1, "[resume] disabled")
+
+    client = WikipediaClient(
+        timeout_s=float(args.timeout_s),
+        requests_per_second=float(args.requests_per_second),
+        cache_path=args.cache_path,
+        log=log,
+    )
+
+    rows: list[dict[str, Any]] = []
+    resume_rows_reused = 0
+    rows_processed_this_run = 0
+
+    total = len(targets)
+    log(1, f"[startup] selected targets: {total}")
+    if total == 0:
+        log(1, "[startup] no targets selected; writing empty payload")
+
+    for idx, (_, target_row) in enumerate(targets.iterrows(), start=1):
+        row = target_row.to_dict()
+        primary_id = str(row.get("primary_id", "")).strip()
+        catalog = str(row.get("catalog", "")).strip()
+        object_type_group = str(row.get("object_type_group", "")).strip()
+        common_name = str(row.get("common_name", "")).strip()
+
+        existing = resume_rows_by_id.get(primary_id)
+        if existing is not None:
+            existing_status = str(existing.get("status", "")).strip().lower()
+            should_retry_no_match = args.retry_no_match and existing_status == "no_match"
+            missing_catalog_enrichment = not _has_catalog_enrichment(existing)
+            if not should_retry_no_match and not missing_catalog_enrichment:
+                rows.append(existing)
+                resume_rows_reused += 1
+                log(
+                    2,
+                    f"[{idx}/{total}] reuse primary_id={primary_id} status={existing_status or 'unknown'} "
+                    f"catalog={catalog}",
+                )
+
+                if args.progress_every > 0 and (idx % args.progress_every == 0 or idx == total):
+                    snapshot = _compute_row_stats(rows)
+                    log(
+                        1,
+                        f"[progress {idx}/{total}] matched={snapshot['matched']} no_match={snapshot['no_match']} "
+                        f"with_image={snapshot['with_image']} with_designations={snapshot['with_designations']} "
+                        f"reused={resume_rows_reused} new={rows_processed_this_run}",
+                        )
+                continue
+            if missing_catalog_enrichment:
+                log(2, f"[{idx}/{total}] retry-missing-enrichment primary_id={primary_id} catalog={catalog}")
+            elif should_retry_no_match:
+                log(2, f"[{idx}/{total}] retry-no-match primary_id={primary_id} catalog={catalog}")
+
+        log(
+            2,
+            f"[{idx}/{total}] process primary_id={primary_id} catalog={catalog} "
+            f"group='{object_type_group}' common_name='{_truncate(common_name, 60)}'",
+        )
+
+        lookup = _resolve_wikipedia_page(row, client, log=log)
+        status = "matched" if lookup.match_method not in {"no_match", "none"} and lookup.title else "no_match"
+
+        rows.append(
+            {
+                "primary_id": primary_id,
+                "catalog": catalog,
+                "object_type_group": object_type_group,
+                "common_name": common_name,
+                "status": status,
+                "match_method": lookup.match_method,
+                "match_score": int(lookup.match_score),
+                "query_used": lookup.query_used,
+                "wikipedia_title": lookup.title,
+                "wikipedia_url": lookup.url,
+                "description": lookup.description,
+                "description_sentence_count": int(lookup.sentence_count),
+                "image_url": lookup.image_url,
+                "designations": lookup.designations,
+                "catalog_enrichment": {
+                    "common_name": lookup.common_name,
+                    "object_type": lookup.object_type,
+                    "ra_deg": lookup.ra_deg,
+                    "dec_deg": lookup.dec_deg,
+                    "constellation": lookup.constellation,
+                    "aliases": lookup.aliases,
+                    "image_url": lookup.image_url,
+                    "image_attribution_url": lookup.image_attribution_url,
+                    "description": lookup.description,
+                    "info_url": lookup.info_url or lookup.url,
+                    "emission_lines": lookup.emission_lines,
+                    "wikipedia_primary_id": lookup.wikipedia_primary_id,
+                    "wikipedia_catalog": lookup.wikipedia_catalog,
+                },
+            }
+        )
+        rows_processed_this_run += 1
+
+        log(
+            2,
+            f"[{idx}/{total}] result status={status} method={lookup.match_method} score={lookup.match_score} "
+            f"title='{_truncate(lookup.title, 70)}' image={'yes' if bool(lookup.image_url) else 'no'} "
+            f"designations={len(lookup.designations)} sentences={lookup.sentence_count}",
+        )
+
+        if args.checkpoint_every > 0 and (rows_processed_this_run % args.checkpoint_every == 0):
+            interim_stats = _compute_row_stats(rows)
+            interim_payload = _build_payload(
+                generated_at_utc=_utc_now_iso(),
+                catalog_path=args.catalog_path,
+                include_catalogs=include_catalogs,
+                include_groups=include_groups,
+                include_primary_ids=include_primary_ids,
+                target_count=total,
+                rows=rows,
+                stats=interim_stats,
+                resume_enabled=bool(args.resume),
+                resume_retry_no_match=bool(args.retry_no_match),
+                resume_rows_reused=resume_rows_reused,
+                rows_processed_this_run=rows_processed_this_run,
+                duration_seconds=(time.monotonic() - run_started),
+                http_stats=client.request_stats(),
+                verbosity=verbosity,
+            )
+            args.output_path.parent.mkdir(parents=True, exist_ok=True)
+            args.output_path.write_text(json.dumps(interim_payload, indent=2, ensure_ascii=True), encoding="utf-8")
+            client.flush_cache()
+            log(
+                1,
+                f"[checkpoint] wrote rows={len(rows)}/{total} reused={resume_rows_reused} new={rows_processed_this_run}",
+            )
+
+        if args.progress_every > 0 and (idx % args.progress_every == 0 or idx == total):
+            snapshot = _compute_row_stats(rows)
+            log(
+                1,
+                f"[progress {idx}/{total}] matched={snapshot['matched']} no_match={snapshot['no_match']} "
+                f"with_image={snapshot['with_image']} with_designations={snapshot['with_designations']} "
+                f"reused={resume_rows_reused} new={rows_processed_this_run}",
+            )
+
+    final_stats = _compute_row_stats(rows)
+    payload = _build_payload(
+        generated_at_utc=_utc_now_iso(),
+        catalog_path=args.catalog_path,
+        include_catalogs=include_catalogs,
+        include_groups=include_groups,
+        include_primary_ids=include_primary_ids,
+        target_count=total,
+        rows=rows,
+        stats=final_stats,
+        resume_enabled=bool(args.resume),
+        resume_retry_no_match=bool(args.retry_no_match),
+        resume_rows_reused=resume_rows_reused,
+        rows_processed_this_run=rows_processed_this_run,
+        duration_seconds=(time.monotonic() - run_started),
+        http_stats=client.request_stats(),
+        verbosity=verbosity,
+    )
+
+    args.output_path.parent.mkdir(parents=True, exist_ok=True)
+    args.output_path.write_text(json.dumps(payload, indent=2, ensure_ascii=True), encoding="utf-8")
+    client.flush_cache()
+
+    log(
+        1,
+        "[done] "
+        f"rows_total={len(rows)} reused={resume_rows_reused} new={rows_processed_this_run} "
+        f"matched={final_stats['matched']} no_match={final_stats['no_match']} "
+        f"with_image={final_stats['with_image']} with_designations={final_stats['with_designations']}",
+    )
+    log(1, f"[done] wrote enrichment JSON: {args.output_path}")
+    log(1, f"[done] wrote API cache JSON: {args.cache_path}")
+    log(1, f"[done] http stats: {client.request_stats()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_wikipedia_enrichment_review_html.py
+++ b/scripts/build_wikipedia_enrichment_review_html.py
@@ -1,0 +1,958 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build a standalone local HTML review page from wikipedia_catalog_enrichment.json.",
+    )
+    parser.add_argument(
+        "--input-path",
+        type=Path,
+        default=Path("data/wikipedia_catalog_enrichment.json"),
+        help="Input enrichment JSON path.",
+    )
+    parser.add_argument(
+        "--output-path",
+        type=Path,
+        default=Path("data/wikipedia_catalog_enrichment_review.html"),
+        help="Output HTML path.",
+    )
+    return parser
+
+
+def _build_html(json_path_for_runtime: str) -> str:
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Wikipedia Enrichment Review</title>
+  <style>
+    :root {{
+      --bg: #f4f5f7;
+      --surface: #ffffff;
+      --text: #111827;
+      --muted: #6b7280;
+      --line: #d1d5db;
+      --accent: #0f766e;
+      --good: #166534;
+      --warn: #9a3412;
+      --reject: #7f1d1d;
+      --shadow: 0 6px 22px rgba(17,24,39,0.08);
+    }}
+    * {{ box-sizing: border-box; }}
+    body {{
+      margin: 0;
+      font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+      color: var(--text);
+      background: radial-gradient(circle at top right, #e6f4f1 0%, var(--bg) 40%);
+    }}
+    .wrap {{
+      max-width: none;
+      margin: 0 auto;
+      padding: 20px 18px 28px;
+    }}
+    .hero {{
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      box-shadow: var(--shadow);
+      padding: 18px;
+      margin-bottom: 14px;
+    }}
+    h1 {{
+      margin: 0 0 6px;
+      font-size: 1.35rem;
+      letter-spacing: 0.01em;
+    }}
+    .meta {{
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }}
+    .stats {{
+      margin-top: 12px;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 8px;
+    }}
+    .stat-btn {{
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      padding: 9px 10px;
+      background: #f8fafc;
+      font-size: 0.85rem;
+      cursor: pointer;
+      text-align: left;
+      color: var(--text);
+    }}
+    .stat-btn.active {{
+      border-color: #0f766e;
+      box-shadow: inset 0 0 0 1px #0f766e;
+      background: #ecfeff;
+    }}
+    .controls {{
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      box-shadow: var(--shadow);
+      padding: 12px;
+      display: grid;
+      grid-template-columns: 1.5fr 0.85fr 0.9fr 0.9fr 0.95fr 1fr 0.7fr auto auto;
+      gap: 8px;
+      margin-bottom: 14px;
+      align-items: center;
+    }}
+    .controls input,
+    .controls select,
+    .controls button {{
+      width: 100%;
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      padding: 8px 10px;
+      background: #fff;
+      font-size: 0.9rem;
+    }}
+    .controls button {{
+      background: #f8fafc;
+      cursor: pointer;
+    }}
+    .controls .check {{
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 0.88rem;
+      color: var(--muted);
+      white-space: nowrap;
+    }}
+    .bulk-controls {{
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      box-shadow: var(--shadow);
+      padding: 10px 12px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      align-items: center;
+      margin-bottom: 14px;
+    }}
+    .selection-summary {{
+      color: var(--muted);
+      font-size: 0.88rem;
+      margin-right: 4px;
+    }}
+    .bulk-controls button {{
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      padding: 8px 10px;
+      background: #f8fafc;
+      font-size: 0.9rem;
+      cursor: pointer;
+    }}
+    .bulk-controls button:disabled {{
+      opacity: 0.45;
+      cursor: default;
+    }}
+    .cards {{
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(290px, 1fr));
+      gap: 12px;
+    }}
+    .card {{
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      box-shadow: var(--shadow);
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      min-height: 390px;
+    }}
+    .img-wrap {{
+      width: 100%;
+      height: 190px;
+      background: #eef2f7;
+      border-bottom: 1px solid var(--line);
+      display: grid;
+      place-items: center;
+      color: var(--muted);
+      font-size: 0.85rem;
+    }}
+    .img-wrap img {{
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }}
+    .body {{
+      padding: 10px 12px 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 7px;
+    }}
+    .title {{
+      margin: 0;
+      font-size: 1rem;
+      line-height: 1.2;
+    }}
+    .subtitle {{
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.82rem;
+      line-height: 1.35;
+    }}
+    .status {{
+      display: inline-block;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      font-size: 0.74rem;
+      padding: 3px 8px;
+      width: fit-content;
+      background: #f8fafc;
+    }}
+    .status.matched {{
+      border-color: #86efac;
+      background: #f0fdf4;
+      color: var(--good);
+    }}
+    .status.no_match {{
+      border-color: #fdba74;
+      background: #fff7ed;
+      color: var(--warn);
+    }}
+    .status.rejected {{
+      border-color: #fca5a5;
+      background: #fef2f2;
+      color: var(--reject);
+    }}
+    .desc {{
+      margin: 0;
+      font-size: 0.9rem;
+      line-height: 1.45;
+    }}
+    .meta-row {{
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin-top: auto;
+    }}
+    .chip {{
+      border: 1px solid var(--line);
+      background: #f8fafc;
+      border-radius: 999px;
+      padding: 3px 8px;
+      font-size: 0.73rem;
+      color: #334155;
+    }}
+    .link {{
+      text-decoration: none;
+      color: var(--accent);
+      font-size: 0.82rem;
+    }}
+    .action-row {{
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 2px;
+    }}
+    .action-btn {{
+      border: 1px solid var(--line);
+      background: #fff;
+      border-radius: 9px;
+      padding: 5px 8px;
+      font-size: 0.78rem;
+      cursor: pointer;
+    }}
+    .action-btn.reject-btn {{
+      border-color: #fecaca;
+      color: var(--reject);
+      background: #fff7f7;
+    }}
+    .action-btn.reject-btn.active {{
+      border-color: #ef4444;
+      color: #fff;
+      background: #b91c1c;
+    }}
+    .select-item {{
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 0.78rem;
+      color: var(--muted);
+      border: 1px solid var(--line);
+      background: #fff;
+      border-radius: 9px;
+      padding: 5px 8px;
+      user-select: none;
+      cursor: pointer;
+    }}
+    .select-item input {{
+      margin: 0;
+    }}
+    .pager {{
+      margin: 14px 0 2px;
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      justify-content: center;
+    }}
+    .pager button {{
+      border: 1px solid var(--line);
+      background: #fff;
+      border-radius: 10px;
+      padding: 8px 10px;
+      cursor: pointer;
+    }}
+    .pager button:disabled {{
+      opacity: 0.45;
+      cursor: default;
+    }}
+    .empty {{
+      text-align: center;
+      color: var(--muted);
+      padding: 24px 0;
+    }}
+    .empty.error {{
+      color: var(--reject);
+      background: #fff5f5;
+      border: 1px solid #fecaca;
+      border-radius: 10px;
+      padding: 12px;
+      margin-bottom: 10px;
+    }}
+    @media (max-width: 1100px) {{
+      .controls {{
+        grid-template-columns: 1fr 1fr 1fr 1fr;
+      }}
+    }}
+    @media (max-width: 680px) {{
+      .controls {{
+        grid-template-columns: 1fr;
+      }}
+    }}
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <section class="hero">
+      <h1>Wikipedia Catalog Enrichment Review</h1>
+      <p class="meta" id="metaLine"></p>
+      <div class="stats" id="topStats"></div>
+    </section>
+
+    <section class="controls">
+      <input id="search" type="search" placeholder="Search title, primary ID, description, designations..." />
+      <select id="statusFilter">
+        <option value="all">All statuses</option>
+        <option value="matched">Matched only</option>
+        <option value="no_match">No match only</option>
+        <option value="rejected">Rejected only</option>
+      </select>
+      <select id="catalogFilter">
+        <option value="all">All catalogs</option>
+      </select>
+      <select id="groupFilter">
+        <option value="all">All object groups</option>
+      </select>
+      <select id="descFilter">
+        <option value="all">All descriptions</option>
+        <option value="with">With description</option>
+        <option value="without">No description only</option>
+      </select>
+      <select id="sortBy">
+        <option value="score_desc">Sort: score high to low</option>
+        <option value="score_asc">Sort: score low to high</option>
+        <option value="title_asc">Sort: title A-Z</option>
+        <option value="primary_asc">Sort: primary ID A-Z</option>
+      </select>
+      <label class="check"><input id="imagesOnly" type="checkbox" /> Image only</label>
+      <select id="pageSize">
+        <option value="24">24 / page</option>
+        <option value="48" selected>48 / page</option>
+        <option value="96">96 / page</option>
+        <option value="200">200 / page</option>
+      </select>
+      <button id="exportRejectedBtn" type="button">Export rejected</button>
+      <button id="clearRejectedBtn" type="button">Clear rejected</button>
+    </section>
+
+    <section class="bulk-controls">
+      <span class="selection-summary" id="selectionSummary">0 selected</span>
+      <button id="selectPageBtn" type="button">Select all on page</button>
+      <button id="clearSelectedBtn" type="button">Clear selected</button>
+      <button id="rejectSelectedBtn" type="button">Reject selected</button>
+      <button id="unrejectSelectedBtn" type="button">Unreject selected</button>
+    </section>
+
+    <div class="empty" id="resultSummary"></div>
+    <section class="cards" id="cards"></section>
+    <div class="pager">
+      <button id="prevBtn">Prev</button>
+      <span id="pageLabel"></span>
+      <button id="nextBtn">Next</button>
+    </div>
+  </div>
+
+  <script>
+    const jsonPath = {json.dumps(json_path_for_runtime, ensure_ascii=True)};
+    const builtAt = {json.dumps(_utc_now_iso(), ensure_ascii=True)};
+    const REJECT_KEY = "wikipedia_enrichment_rejected_primary_ids_v1";
+
+    let payload = {{}};
+    let targets = [];
+    let generatedAt = "";
+    let selection = {{}};
+    let stats = {{}};
+
+    let currentPage = 1;
+    let metricFilter = "all";
+    let currentPageRows = [];
+
+    const searchEl = document.getElementById("search");
+    const statusEl = document.getElementById("statusFilter");
+    const catalogEl = document.getElementById("catalogFilter");
+    const groupEl = document.getElementById("groupFilter");
+    const descFilterEl = document.getElementById("descFilter");
+    const sortEl = document.getElementById("sortBy");
+    const imageOnlyEl = document.getElementById("imagesOnly");
+    const pageSizeEl = document.getElementById("pageSize");
+    const cardsEl = document.getElementById("cards");
+    const resultSummaryEl = document.getElementById("resultSummary");
+    const pageLabelEl = document.getElementById("pageLabel");
+    const prevBtnEl = document.getElementById("prevBtn");
+    const nextBtnEl = document.getElementById("nextBtn");
+    const topStatsEl = document.getElementById("topStats");
+    const exportRejectedBtnEl = document.getElementById("exportRejectedBtn");
+    const clearRejectedBtnEl = document.getElementById("clearRejectedBtn");
+    const selectionSummaryEl = document.getElementById("selectionSummary");
+    const selectPageBtnEl = document.getElementById("selectPageBtn");
+    const clearSelectedBtnEl = document.getElementById("clearSelectedBtn");
+    const rejectSelectedBtnEl = document.getElementById("rejectSelectedBtn");
+    const unrejectSelectedBtnEl = document.getElementById("unrejectSelectedBtn");
+
+    const rejectedIds = loadRejectedSet();
+    const selectedIds = new Set();
+
+    function norm(v) {{
+      return String(v || "").toLowerCase();
+    }}
+
+    function primaryIdOf(row) {{
+      return String((row && row.primary_id) || "").trim();
+    }}
+
+    function loadRejectedSet() {{
+      try {{
+        const raw = localStorage.getItem(REJECT_KEY);
+        if (!raw) return new Set();
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed)) return new Set();
+        return new Set(parsed.map((item) => String(item || "").trim()).filter(Boolean));
+      }} catch (_err) {{
+        return new Set();
+      }}
+    }}
+
+    function saveRejectedSet() {{
+      try {{
+        localStorage.setItem(REJECT_KEY, JSON.stringify(Array.from(rejectedIds).sort()));
+      }} catch (_err) {{
+        // noop
+      }}
+    }}
+
+    function isRejectedRow(row) {{
+      const pid = primaryIdOf(row);
+      return Boolean(pid) && rejectedIds.has(pid);
+    }}
+
+    function effectiveStatus(row) {{
+      if (isRejectedRow(row)) return "rejected";
+      return norm(row.status) || "unknown";
+    }}
+
+    function hasImage(row) {{
+      return String(row.image_url || "").trim() !== "";
+    }}
+
+    function hasDesignations(row) {{
+      return Array.isArray(row.designations) && row.designations.length > 0;
+    }}
+
+    function hasDescription(row) {{
+      const text = String(row.description || "").trim();
+      if (!text) return false;
+      const lowered = norm(text);
+      return lowered !== "no description available." && lowered !== "no description available";
+    }}
+
+    function topText() {{
+      const selCatalogs = (selection.catalogs || []).join(", ");
+      const selGroups = (selection.object_type_groups || []).join(", ");
+      return `Source JSON: ${{jsonPath}} | Generated: ${{generatedAt || "-"}} | HTML built: ${{builtAt}} | Catalogs: ${{selCatalogs || "-"}} | Groups: ${{selGroups || "-"}}`;
+    }}
+
+    function computeCounts() {{
+      let matched = 0;
+      let noMatch = 0;
+      let rejected = 0;
+      let withImage = 0;
+      let withDesignations = 0;
+
+      for (const row of targets) {{
+        const s = effectiveStatus(row);
+        if (s === "matched") matched += 1;
+        else if (s === "no_match") noMatch += 1;
+        else if (s === "rejected") rejected += 1;
+
+        if (hasImage(row)) withImage += 1;
+        if (hasDesignations(row)) withDesignations += 1;
+      }}
+
+      return {{
+        total: targets.length,
+        matched,
+        no_match: noMatch,
+        rejected,
+        with_image: withImage,
+        with_designations: withDesignations,
+      }};
+    }}
+
+    function renderStats() {{
+      document.getElementById("metaLine").textContent = topText();
+      const counts = computeCounts();
+      const items = [
+        {{ key: "all", label: "All", value: counts.total }},
+        {{ key: "matched", label: "Matched", value: counts.matched }},
+        {{ key: "no_match", label: "No Match", value: counts.no_match }},
+        {{ key: "rejected", label: "Rejected", value: counts.rejected }},
+        {{ key: "with_image", label: "With Image", value: counts.with_image }},
+        {{ key: "with_designations", label: "With Designations", value: counts.with_designations }},
+      ];
+      topStatsEl.innerHTML = items
+        .map((item) => `
+          <button type="button" class="stat-btn ${{metricFilter === item.key ? "active" : ""}}" data-metric="${{item.key}}">
+            <strong>${{item.label}}:</strong> ${{item.value}}
+          </button>
+        `)
+        .join("");
+    }}
+
+    function populateSelect(selectEl, values, allLabel) {{
+      const current = selectEl.value || "all";
+      const options = [`<option value="all">${{allLabel}}</option>`]
+        .concat(values.map((v) => `<option value="${{v}}">${{v}}</option>`));
+      selectEl.innerHTML = options.join("");
+      if (values.includes(current)) selectEl.value = current;
+      else selectEl.value = "all";
+    }}
+
+    function populateDropdowns() {{
+      const catalogs = Array.from(
+        new Set(targets.map((row) => String(row.catalog || "").trim()).filter(Boolean))
+      ).sort((a, b) => a.localeCompare(b));
+
+      const groups = Array.from(
+        new Set(targets.map((row) => String(row.object_type_group || "").trim()).filter(Boolean))
+      ).sort((a, b) => a.localeCompare(b));
+
+      populateSelect(catalogEl, catalogs, "All catalogs");
+      populateSelect(groupEl, groups, "All object groups");
+    }}
+
+    function pagePrimaryIds() {{
+      return currentPageRows.map(primaryIdOf).filter(Boolean);
+    }}
+
+    function selectedOnPageCount() {{
+      return pagePrimaryIds().filter((id) => selectedIds.has(id)).length;
+    }}
+
+    function allPageItemsSelected() {{
+      const ids = pagePrimaryIds();
+      return ids.length > 0 && ids.every((id) => selectedIds.has(id));
+    }}
+
+    function updateSelectionControls() {{
+      const pageIds = pagePrimaryIds();
+      const selectedOnPage = selectedOnPageCount();
+      selectionSummaryEl.textContent = `${{selectedIds.size}} selected (${{selectedOnPage}} on page)`;
+
+      selectPageBtnEl.disabled = pageIds.length === 0;
+      selectPageBtnEl.textContent = allPageItemsSelected() ? "Unselect page" : "Select all on page";
+      clearSelectedBtnEl.disabled = selectedIds.size === 0;
+      rejectSelectedBtnEl.disabled = selectedIds.size === 0;
+      unrejectSelectedBtnEl.disabled = selectedIds.size === 0;
+    }}
+
+    function togglePageSelection() {{
+      const ids = pagePrimaryIds();
+      if (!ids.length) return;
+      const allSelected = ids.every((id) => selectedIds.has(id));
+      if (allSelected) {{
+        ids.forEach((id) => selectedIds.delete(id));
+      }} else {{
+        ids.forEach((id) => selectedIds.add(id));
+      }}
+      render();
+    }}
+
+    function applyBulkReject(shouldReject) {{
+      if (!selectedIds.size) return;
+      let changed = 0;
+      for (const id of selectedIds) {{
+        if (shouldReject) {{
+          if (!rejectedIds.has(id)) {{
+            rejectedIds.add(id);
+            changed += 1;
+          }}
+        }} else if (rejectedIds.has(id)) {{
+          rejectedIds.delete(id);
+          changed += 1;
+        }}
+      }}
+      if (!changed) return;
+      saveRejectedSet();
+      currentPage = 1;
+      renderStats();
+      render();
+    }}
+
+    function passesMetricFilter(row) {{
+      if (metricFilter === "all") return true;
+      if (metricFilter === "matched") return effectiveStatus(row) === "matched";
+      if (metricFilter === "no_match") return effectiveStatus(row) === "no_match";
+      if (metricFilter === "rejected") return effectiveStatus(row) === "rejected";
+      if (metricFilter === "with_image") return hasImage(row);
+      if (metricFilter === "with_designations") return hasDesignations(row);
+      return true;
+    }}
+
+    function filtered() {{
+      const q = norm(searchEl.value).trim();
+      const status = statusEl.value;
+      const selectedCatalog = catalogEl.value;
+      const selectedGroup = groupEl.value;
+      const descMode = descFilterEl.value;
+      const imageOnly = imageOnlyEl.checked;
+
+      let rows = targets.filter((row) => {{
+        if (status !== "all" && effectiveStatus(row) !== status) return false;
+        if (!passesMetricFilter(row)) return false;
+
+        const catalogValue = String(row.catalog || "").trim();
+        if (selectedCatalog !== "all" && catalogValue !== selectedCatalog) return false;
+
+        const groupValue = String(row.object_type_group || "").trim();
+        if (selectedGroup !== "all" && groupValue !== selectedGroup) return false;
+
+        if (descMode === "with" && !hasDescription(row)) return false;
+        if (descMode === "without" && hasDescription(row)) return false;
+
+        if (imageOnly && !hasImage(row)) return false;
+
+        if (!q) return true;
+        const fields = [
+          row.primary_id,
+          row.wikipedia_title,
+          row.common_name,
+          row.description,
+          row.object_type_group,
+          row.catalog,
+          Array.isArray(row.designations) ? row.designations.join(" ") : "",
+        ].map(norm);
+        return fields.some((field) => field.includes(q));
+      }});
+
+      if (sortEl.value === "score_desc") {{
+        rows.sort((a, b) => Number(b.match_score || 0) - Number(a.match_score || 0));
+      }} else if (sortEl.value === "score_asc") {{
+        rows.sort((a, b) => Number(a.match_score || 0) - Number(b.match_score || 0));
+      }} else if (sortEl.value === "title_asc") {{
+        rows.sort((a, b) => String(a.wikipedia_title || a.primary_id || "").localeCompare(String(b.wikipedia_title || b.primary_id || "")));
+      }} else if (sortEl.value === "primary_asc") {{
+        rows.sort((a, b) => String(a.primary_id || "").localeCompare(String(b.primary_id || "")));
+      }}
+
+      return rows;
+    }}
+
+    function card(row) {{
+      const title = row.wikipedia_title || row.primary_id || "Unknown";
+      const reviewStatus = effectiveStatus(row);
+      const statusClass = reviewStatus === "matched" ? "matched" : (reviewStatus === "rejected" ? "rejected" : "no_match");
+      const statusLabel = reviewStatus === "rejected" ? "Rejected" : (row.status || "unknown");
+      const desc = hasDescription(row) ? String(row.description || "").trim() : "No description available.";
+      const image = String(row.image_url || "").trim();
+      const wiki = String(row.wikipedia_url || "").trim();
+      const designations = Array.isArray(row.designations) ? row.designations.slice(0, 6) : [];
+      const primaryId = primaryIdOf(row);
+      const pidEncoded = encodeURIComponent(primaryId);
+      const rejected = reviewStatus === "rejected";
+      const isSelected = Boolean(primaryId) && selectedIds.has(primaryId);
+
+      const imgHtml = image
+        ? `<img loading="lazy" src="${{image}}" alt="${{title}}" />`
+        : `<span>No image</span>`;
+
+      const chips = [
+        `catalog: ${{row.catalog || "-"}}`,
+        `group: ${{row.object_type_group || "-"}}`,
+        `score: ${{row.match_score ?? "-"}}`,
+        `sentences: ${{row.description_sentence_count ?? 0}}`,
+      ];
+      if (rejected) chips.push("review: rejected");
+      const chipHtml = chips.map((x) => `<span class="chip">${{x}}</span>`).join("");
+
+      const designationHtml = designations.length
+        ? `<div class="meta-row">${{designations.map((d) => `<span class="chip">${{d}}</span>`).join("")}}</div>`
+        : "";
+
+      const linkHtml = wiki ? `<a class="link" target="_blank" rel="noopener noreferrer" href="${{wiki}}">Open Wikipedia page</a>` : "";
+      const subtitle = `${{row.primary_id || "-"}} • ${{row.common_name || "No common name"}}`;
+      const rejectBtnHtml = primaryId
+        ? `<button type="button" class="action-btn reject-btn ${{rejected ? "active" : ""}}" data-reject-id="${{pidEncoded}}">${{rejected ? "Unreject" : "Reject"}}</button>`
+        : "";
+      const selectHtml = primaryId
+        ? `<label class="select-item"><input type="checkbox" data-select-id="${{pidEncoded}}" ${{isSelected ? "checked" : ""}} /> Select</label>`
+        : "";
+
+      return `
+        <article class="card">
+          <div class="img-wrap">${{imgHtml}}</div>
+          <div class="body">
+            <h3 class="title">${{title}}</h3>
+            <p class="subtitle">${{subtitle}}</p>
+            <span class="status ${{statusClass}}">${{statusLabel}}</span>
+            <p class="desc">${{desc}}</p>
+            <div class="action-row">${{rejectBtnHtml}}${{selectHtml}}</div>
+            ${{linkHtml}}
+            <div class="meta-row">${{chipHtml}}</div>
+            ${{designationHtml}}
+          </div>
+        </article>
+      `;
+    }}
+
+    function render() {{
+      resultSummaryEl.classList.remove("error");
+      const rows = filtered();
+      const pageSize = Number(pageSizeEl.value || 48);
+      const totalPages = Math.max(1, Math.ceil(rows.length / pageSize));
+      if (currentPage > totalPages) currentPage = totalPages;
+      if (currentPage < 1) currentPage = 1;
+
+      const start = (currentPage - 1) * pageSize;
+      const end = start + pageSize;
+      const pageRows = rows.slice(start, end);
+      currentPageRows = pageRows;
+
+      const metricText = metricFilter === "all" ? "all metrics" : `metric=${{metricFilter}}`;
+      resultSummaryEl.textContent = `Showing ${{pageRows.length}} of ${{rows.length}} filtered targets (${{targets.length}} total, ${{metricText}}, ${{rejectedIds.size}} rejected locally, ${{selectedIds.size}} selected).`;
+      pageLabelEl.textContent = `Page ${{currentPage}} / ${{totalPages}}`;
+      prevBtnEl.disabled = currentPage <= 1;
+      nextBtnEl.disabled = currentPage >= totalPages;
+
+      if (!pageRows.length) {{
+        cardsEl.innerHTML = "";
+        resultSummaryEl.textContent = "No targets match this filter.";
+        updateSelectionControls();
+        return;
+      }}
+      cardsEl.innerHTML = pageRows.map(card).join("");
+      updateSelectionControls();
+    }}
+
+    function downloadJson(filename, obj) {{
+      const blob = new Blob([JSON.stringify(obj, null, 2)], {{ type: "application/json" }});
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    }}
+
+    function showLoadError(message) {{
+      cardsEl.innerHTML = "";
+      currentPageRows = [];
+      pageLabelEl.textContent = "";
+      prevBtnEl.disabled = true;
+      nextBtnEl.disabled = true;
+      resultSummaryEl.classList.add("error");
+      resultSummaryEl.textContent = message;
+      updateSelectionControls();
+    }}
+
+    async function loadPayload() {{
+      resultSummaryEl.classList.remove("error");
+      resultSummaryEl.textContent = `Loading enrichment data from ${{jsonPath}} ...`;
+      try {{
+        const response = await fetch(jsonPath, {{ cache: "no-store" }});
+        if (!response.ok) throw new Error(`HTTP ${{response.status}}`);
+
+        const loaded = await response.json();
+        if (!loaded || typeof loaded !== "object") throw new Error("JSON payload is not an object");
+
+        payload = loaded;
+        targets = Array.isArray(payload.targets) ? payload.targets : [];
+        generatedAt = payload.generated_at_utc || "";
+        selection = payload.selection || {{}};
+        stats = payload.stats || {{}};
+
+        const validIds = new Set(targets.map(primaryIdOf).filter(Boolean));
+        for (const id of Array.from(selectedIds)) {{
+          if (!validIds.has(id)) selectedIds.delete(id);
+        }}
+
+        populateDropdowns();
+        renderStats();
+        render();
+      }} catch (error) {{
+        console.error(error);
+        const hint = window.location.protocol === "file:"
+          ? " If you opened this via file://, start a local server (python -m http.server 8000) and open http://127.0.0.1:8000/data/wikipedia_catalog_enrichment_review.html."
+          : "";
+        showLoadError(`Failed to load enrichment JSON at ${{jsonPath}}. ${{error.message || error}}.${{hint}}`);
+      }}
+    }}
+
+    [searchEl, statusEl, catalogEl, groupEl, descFilterEl, sortEl, imageOnlyEl, pageSizeEl].forEach((el) => {{
+      el.addEventListener("input", () => {{
+        currentPage = 1;
+        render();
+      }});
+      el.addEventListener("change", () => {{
+        currentPage = 1;
+        render();
+      }});
+    }});
+
+    topStatsEl.addEventListener("click", (event) => {{
+      const button = event.target.closest("button[data-metric]");
+      if (!button) return;
+      const next = String(button.getAttribute("data-metric") || "all");
+      metricFilter = metricFilter === next ? "all" : next;
+      currentPage = 1;
+      renderStats();
+      render();
+    }});
+
+    cardsEl.addEventListener("click", (event) => {{
+      const btn = event.target.closest("button[data-reject-id]");
+      if (!btn) return;
+      const encoded = btn.getAttribute("data-reject-id") || "";
+      const primaryId = decodeURIComponent(encoded);
+      if (!primaryId) return;
+      if (rejectedIds.has(primaryId)) rejectedIds.delete(primaryId);
+      else rejectedIds.add(primaryId);
+      saveRejectedSet();
+      currentPage = 1;
+      renderStats();
+      render();
+    }});
+
+    cardsEl.addEventListener("change", (event) => {{
+      const input = event.target.closest("input[type='checkbox'][data-select-id]");
+      if (!input) return;
+      const encoded = input.getAttribute("data-select-id") || "";
+      const primaryId = decodeURIComponent(encoded);
+      if (!primaryId) return;
+      if (input.checked) selectedIds.add(primaryId);
+      else selectedIds.delete(primaryId);
+      render();
+    }});
+
+    selectPageBtnEl.addEventListener("click", () => {{
+      togglePageSelection();
+    }});
+
+    clearSelectedBtnEl.addEventListener("click", () => {{
+      if (!selectedIds.size) return;
+      selectedIds.clear();
+      render();
+    }});
+
+    rejectSelectedBtnEl.addEventListener("click", () => {{
+      applyBulkReject(true);
+    }});
+
+    unrejectSelectedBtnEl.addEventListener("click", () => {{
+      applyBulkReject(false);
+    }});
+
+    exportRejectedBtnEl.addEventListener("click", () => {{
+      const ids = Array.from(rejectedIds).sort();
+      const rejectedTargets = targets.filter((row) => ids.includes(String(row.primary_id || "").trim()));
+      const exportPayload = {{
+        exported_at_utc: new Date().toISOString(),
+        source_json: jsonPath,
+        rejected_count: ids.length,
+        rejected_primary_ids: ids,
+        rejected_targets: rejectedTargets,
+      }};
+      downloadJson("wikipedia_catalog_rejected_targets.json", exportPayload);
+    }});
+
+    clearRejectedBtnEl.addEventListener("click", () => {{
+      if (!rejectedIds.size) return;
+      if (!window.confirm(`Clear ${{rejectedIds.size}} rejected targets?`)) return;
+      rejectedIds.clear();
+      saveRejectedSet();
+      currentPage = 1;
+      renderStats();
+      render();
+    }});
+
+    prevBtnEl.addEventListener("click", () => {{
+      currentPage -= 1;
+      render();
+    }});
+    nextBtnEl.addEventListener("click", () => {{
+      currentPage += 1;
+      render();
+    }});
+
+    updateSelectionControls();
+    loadPayload();
+  </script>
+</body>
+</html>
+"""
+
+
+def main() -> None:
+    args = _build_arg_parser().parse_args()
+    if not args.input_path.exists():
+        raise FileNotFoundError(f"Input JSON not found: {args.input_path}")
+
+    payload = json.loads(args.input_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Input JSON payload must be an object: {args.input_path}")
+
+    json_path_for_runtime = Path(
+        os.path.relpath(args.input_path.resolve(), args.output_path.parent.resolve())
+    ).as_posix()
+
+    html = _build_html(json_path_for_runtime)
+    args.output_path.parent.mkdir(parents=True, exist_ok=True)
+    args.output_path.write_text(html, encoding="utf-8")
+    print(f"Wrote review HTML: {args.output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a standalone Wikipedia enrichment builder (`scripts/build_wikipedia_catalog_enrichment.py`) with:
  - resume/checkpoint support
  - verbose progress output
  - include-primary-id targeting (including IDs not in cache)
  - improved Messier fallback query behavior (`M n` then `Messier n`)
  - redirect-aware handling and enrichment payload expansion
- add a merge utility to apply enrichment JSON into parquet cache (`scripts/apply_wikipedia_catalog_enrichment.py`), including updates for existing rows and inserts for missing objects when coordinate requirements are met
- add an HTML review app generator (`scripts/build_wikipedia_enrichment_review_html.py`) and generated review page (`data/wikipedia_catalog_enrichment_review.html`) with filtering and rejection workflows
- document catalog/network dataflow (`CATALOG_DATAFLOW.md`) and refresh cache policy notes in docs
- adjust cache loading policy to on-demand refresh and add `HIIReg` mapping to object type groups

## Validation
- `./.venv/bin/python -m py_compile catalog_ingestion.py scripts/build_wikipedia_catalog_enrichment.py scripts/apply_wikipedia_catalog_enrichment.py scripts/build_wikipedia_enrichment_review_html.py`
- `./.venv/bin/python scripts/build_wikipedia_catalog_enrichment.py --help`
- `./.venv/bin/python scripts/apply_wikipedia_catalog_enrichment.py --help`
- `./.venv/bin/python scripts/build_wikipedia_enrichment_review_html.py --help`

## Notes
- generated local data/cache artifacts (enrichment JSON, API cache, parquet cache files) were intentionally not committed.
