### PR TITLE
Refactor Favorites/Set List into generic Lists subsystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A responsive Streamlit prototype for exploring deep sky objects across Messier, 
 - Desktop split layout and phone-style stacked layout preview
 - Location controls (default Princeton, manual geocode, browser geolocation permission flow, IP fallback)
 - 16-bin obstruction editor (default 20 deg)
-- Favorites and Set List with browser-local persistence (per user/device)
+- Generic Lists (including `Auto (Recent)` + editable custom lists) with browser-local persistence
 - Settings export/import via JSON for backup or migration to another machine
 - Catalog ingestion module with normalized schema + disk cache + metadata
 - Target detail panel with:
@@ -94,7 +94,7 @@ Notes:
 - more instructional content
 - "about this app" page with contact info
 
-- have multiple set lists
+- expand list planning workflows (templates, quick actions, nicknames)
 - ability to give a nickname to an object
 
 - for each wind4, for each hour, find the best target of each type (emission? galaxy? cluster?) in terms of number of minutes in the sweet zone (unobstructed, not too high/low based on mount)

--- a/TODO.md
+++ b/TODO.md
@@ -18,9 +18,9 @@
 
 ## Phase 3: Core Product Loop
 - [x] Search + results + target detail wired to live Alt/Az calculations.
-- [x] Favorites + Set List persistence.
+- [x] Generic list persistence (including auto recent list).
 - [x] Obstruction 16-bin editor applied to visibility calculations.
-- [ ] Set List reorder UX improvements and quick actions.
+- [ ] List reorder UX improvements and quick actions.
 - [ ] Better empty/loading/error states in detail panel.
 
 ## Phase 4: Data Enrichment
@@ -48,17 +48,26 @@
 - [ ] add resilience for missing weather data
 - [ ] add lunar interference model
 - [ ] add the notion of "sweet spot" (visible, unobstructed, not in danger zone of mounts, no lunar interference)
-- [ ] disconnect night sky preview from "pinning", introduce more general list concept
+- [x] disconnect night sky preview from "pinning", introduce more general list concept
 - [ ] look at things like https://en.wikipedia.org/wiki/Lists_of_nebulae for catalog enrichment
 - [ ] integrate barnard objects, caldwell objects
+- [ ] use panoramic picture for obstructions and as overlay in night view
+- [ ] 
   
 ## launch Phase
 - [ ] build github pages based website
 - [ ] create product usage documentation- wiki?
 - [ ] create hero images of app 
 - [ ] integrate some sort of uservoice system for bug tracking
-
+- [ ] survey to gauge interest, locations, equipment 
 
 ## refactoring plans
 - [ ] pull weather service out into its own folder
 - [ ] break up main UI (search, forecast, details, night sky preview) into files/folders
+
+
+
+
+
+
+./.venv/bin/python scripts/build_wikipedia_catalog_enrichment.py --no-resume --output-path data/wikipedia_catalog_enrichment.json --cache-path data/wikipedia_api_cache.json --verbosity 2

--- a/dso_explorer_web_prd_v1.md
+++ b/dso_explorer_web_prd_v1.md
@@ -1,17 +1,17 @@
-# DSO Explorer — Web Prototype PRD (v1.2)
+# DSO Explorer — Web Prototype PRD (v1.3)
 
-> This document supersedes `dso_explorer_web_prd_v0.md` and reflects the implemented product state through **February 13, 2026**.
+> This document supersedes `dso_explorer_web_prd_v0.md` and reflects the implemented product state through **February 15, 2026**.
 
-- Updated: 2026-02-13
+- Updated: 2026-02-15
 - Platforms: phone + tablet + laptop (responsive)
 - Runtime target: Streamlit Community Cloud (private GitHub repo supported)
 
 ## 1. Product goals
 
 - Unified discovery across Messier, NGC, IC, and Sharpless (Sh2).
-- Fast loop: Search -> Select target -> Review detail + plots -> Save to Favorites / Set List.
+- Fast loop: Search -> Select target -> Review detail + plots -> Add to user-defined Lists.
 - Reliable real-time sky context using current location and 60s Alt/Az refresh.
-- Local/session persistence of user preferences (favorites, set list, location, obstructions, display choices).
+- Local/session persistence of user preferences (lists, location, obstructions, display choices).
 
 ## 2. Non-goals
 
@@ -86,6 +86,7 @@
 - Settings page sections are implemented and grouped as:
 - Location
 - Display
+- Lists
 - Catalog
 - Obstructions
 - Settings Backup / Restore
@@ -93,7 +94,7 @@
 
 ### 3.6 Detail panel
 
-- Header with ID/name + Favorite and Set List toggles.
+- Header with ID/name + a single `Add to list...` action.
 - Three-column detail layout:
 - Left: image
 - Middle: description + links
@@ -123,7 +124,7 @@
 - `false`: center = 0 deg altitude.
 - Style and dome preferences persist across target switches.
 - Selected target always renders as full-night path.
-- Set List targets render as additional full-night paths (same sunset->sunrise window).
+- Targets from the currently selected preview list render as additional full-night paths (same sunset->sunrise window).
 - All plotted target paths are solid lines and color-coded by target.
 - Event labels are rendered per plotted target:
 - `Rise`, `Set`, `First Visible`, `Last Visible`, `Culmination`.
@@ -135,11 +136,12 @@
 - Columns:
 - `Line` (color swatch)
 - `Target`
-- `Rise`, `First Visible`, `Culmination`, `Last Visible`, `Set`
-- `Visible` (total visible duration across tonight window)
-- `Culm Dir` (compass direction at culmination)
-- `Set List` (Pinned/Unpinned state)
-- Multi-row selection supports bulk Set List toggling via `Toggle Selected` action.
+- `Type`
+- `First Visible`, `Peak`, `Last Visible`
+- `Duration` (+ `Remaining` during the active night window)
+- `Max Alt`, `Direction`
+- `List` (`Add`/`Remove`, or `Auto` for system-managed lists)
+- Row selection highlights the target used for the Target Tips panel without changing the detail target selection.
 
 - Hourly Forecast plot:
 - Stacked hourly bars where total height is hourly max altitude.
@@ -161,8 +163,8 @@
 ### 3.9 Persistence model
 
 - Preferences persisted locally when filesystem is writable:
-- Favorites
-- Set List order
+- Lists payload + list order + list metadata
+- Active preview list selection
 - Last valid location
 - 16-bin obstructions
 - Temperature preference
@@ -187,15 +189,15 @@
 
 - User can search across M/NGC/IC/SH2 and select a target from search suggestions.
 - App provides dedicated `Explorer` and `Settings` pages with stable navigation.
-- Settings page contains clearly defined sections for location, display, catalog, obstructions, and settings backup/restore.
+- Settings page contains clearly defined sections for location, display, lists, catalog, obstructions, and settings backup/restore.
 - Catalog load path supports enriched-first ingest with cache-only ID supplementation, preserving enriched values for overlapping IDs.
 - Detail panel shows required metadata, list actions, image/source/background attribution behavior, and two always-visible plots.
 - Detail panel uses the implemented 3-column layout with image scaling at max 400x400 and preserved aspect ratio.
 - Detail property table hides blank rows and surfaces enriched fields where available.
 - Sky plot supports Line/Radial and radial Dome View axis inversion.
-- Sky plot includes full-night paths for selected + Set List targets, per-target event labels, and directional movement arrows.
+- Sky plot includes full-night paths for selected + active-preview-list targets, per-target event labels, and directional movement arrows.
 - Sky obstruction rendering uses hard stepped per-direction floors in light gray.
-- Sky Position summary appears under the chart as a sortable table with event times, total visible time, culmination direction, and bulk Set List toggling.
+- Sky Position summary appears under the chart as a sortable table with event timing/duration columns and per-row list membership actions.
 - Hourly plot renders stacked obstructed/clear bars with direction and temperature labeling.
 - Alt/Az refreshes at least every 60 seconds.
 - Browser geolocation failure cases do not replace prior valid location.
@@ -256,3 +258,7 @@
 - description + source/background links column
 - enriched property/value table
 - Detail property table row rendering adjusted to suppress blank visual rows (commit `d991f41`).
+- Lists refactor:
+- Removed Favorites/Set List tab model in favor of generic lists with `Auto (Recent)` default preview binding.
+- Added Settings list-management controls (create, rename, reorder, delete) for editable lists.
+- Search ranking now prioritizes targets that appear in any list, not only legacy favorites.

--- a/list_search.py
+++ b/list_search.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Callable, Mapping
+
+import astropy.units as u
+import numpy as np
+import pandas as pd
+from astropy.time import Time
+
+
+def normalize_text(value: str | None) -> str:
+    if value is None:
+        return ""
+    return re.sub(r"[^a-z0-9]", "", value.lower())
+
+
+def subset_by_id_list(frame: pd.DataFrame, ordered_ids: list[str]) -> pd.DataFrame:
+    if not ordered_ids:
+        return frame.iloc[0:0].copy()
+
+    id_rank = {identifier: idx for idx, identifier in enumerate(ordered_ids)}
+    subset = frame[frame["primary_id"].isin(id_rank)].copy()
+    if subset.empty:
+        return subset
+
+    subset["_rank"] = subset["primary_id"].map(id_rank)
+    subset = subset.sort_values(by="_rank", ascending=True).drop(columns=["_rank"]).reset_index(drop=True)
+    return subset
+
+
+def format_search_suggestion(
+    row: pd.Series,
+    *,
+    is_listed: bool,
+    wind16_arrows: Mapping[str, str],
+) -> str:
+    primary_id = str(row.get("primary_id") or "").strip() or "Unknown ID"
+    common_name = str(row.get("common_name") or "").strip()
+    object_type = str(row.get("object_type") or "").strip() or "Unknown type"
+    wind = str(row.get("wind16") or "").strip() or "--"
+    arrow = str(wind16_arrows.get(wind, " ")) or " "
+    alt_now = row.get("alt_now")
+    try:
+        alt_text = f"{float(alt_now):.0f} deg"
+    except (TypeError, ValueError):
+        alt_text = "--"
+
+    id_and_name = f"{primary_id} - {common_name}" if common_name else primary_id
+    listed_suffix = " [list]" if is_listed else ""
+    return f"{id_and_name} • {object_type} • {arrow} {wind} {alt_text}{listed_suffix}"
+
+
+def catalog_search_rank(catalog_value: str | None) -> int:
+    norm = normalize_text(catalog_value)
+    if norm in {"m", "messier"} or norm.startswith("messier"):
+        return 0
+    if norm.startswith("sha") or norm.startswith("sh2") or norm.startswith("sh") or norm.startswith("sharpless"):
+        return 1
+    if norm.startswith("ic"):
+        return 2
+    if norm.startswith("ngc"):
+        return 3
+    return 4
+
+
+def object_type_group_search_rank(object_type_group_value: str | None) -> int:
+    norm = normalize_text(object_type_group_value)
+    if norm in {"galaxy", "galaxies"}:
+        return 0
+    if norm == "brightnebula":
+        return 1
+    if norm == "darknebula":
+        return 2
+    if norm == "clusters":
+        return 3
+    if norm == "stars":
+        return 4
+    if norm == "other":
+        return 5
+    return 6
+
+
+def compute_abs_minutes_to_culmination(targets: pd.DataFrame, lon: float) -> pd.Series:
+    if targets.empty or "ra_deg" not in targets.columns:
+        return pd.Series(np.inf, index=targets.index, dtype=float)
+
+    try:
+        now_utc = Time(datetime.now(timezone.utc))
+        lst_deg = float(now_utc.sidereal_time("apparent", longitude=float(lon) * u.deg).degree) % 360.0
+    except Exception:
+        return pd.Series(np.inf, index=targets.index, dtype=float)
+
+    ra_values = pd.to_numeric(targets["ra_deg"], errors="coerce").to_numpy(dtype=float)
+    abs_minutes = np.full(len(targets), np.inf, dtype=float)
+    valid = np.isfinite(ra_values)
+    if np.any(valid):
+        hour_angle_deg = ((lst_deg - ra_values[valid] + 540.0) % 360.0) - 180.0
+        abs_minutes[valid] = np.abs(hour_angle_deg) * 4.0
+
+    return pd.Series(abs_minutes, index=targets.index, dtype=float)
+
+
+def searchbox_target_options(
+    search_term: str,
+    *,
+    catalog: pd.DataFrame,
+    lat: float,
+    lon: float,
+    listed_ids: list[str] | set[str] | None,
+    max_options: int,
+    wind16_arrows: Mapping[str, str],
+    search_catalog_fn: Callable[[pd.DataFrame, str], pd.DataFrame],
+    compute_altaz_now_fn: Callable[[pd.DataFrame, float, float], pd.DataFrame],
+) -> list[tuple[str, str]]:
+    query = str(search_term or "").strip()
+    if not query:
+        return []
+
+    listed_list = [str(value) for value in (listed_ids or [])]
+    listed_set = set(listed_list)
+    query_norm = normalize_text(query)
+    list_query_terms = {"list", "lists", "listed"}
+    if query_norm in list_query_terms:
+        matches = subset_by_id_list(catalog, listed_list).copy()
+    else:
+        matches = search_catalog_fn(catalog, query).copy()
+        if "object_type_group" in catalog.columns and query_norm:
+            group_norm = catalog["object_type_group"].fillna("").astype(str).map(normalize_text)
+            group_matches = catalog[group_norm.str.contains(query_norm, regex=False)].copy()
+            if not group_matches.empty:
+                if matches.empty:
+                    matches = group_matches
+                else:
+                    matches = (
+                        pd.concat([matches, group_matches], ignore_index=True)
+                        .drop_duplicates(subset=["primary_id"], keep="first")
+                        .reset_index(drop=True)
+                    )
+    if matches.empty:
+        return []
+
+    matches = compute_altaz_now_fn(matches, lat=lat, lon=lon)
+    if query_norm not in list_query_terms:
+        matches["_listed_rank"] = np.where(matches["primary_id"].astype(str).isin(listed_set), 0, 1)
+        matches["_horizon_rank"] = np.where(
+            pd.to_numeric(matches["alt_now"], errors="coerce").fillna(-9999.0) >= 0.0,
+            0,
+            1,
+        )
+        matches["_catalog_rank"] = matches["catalog"].map(catalog_search_rank)
+        matches["_type_group_rank"] = matches["object_type_group"].map(object_type_group_search_rank)
+        matches["_altitude_sort"] = pd.to_numeric(matches["alt_now"], errors="coerce").fillna(-9999.0)
+        matches["_culm_abs_minutes"] = compute_abs_minutes_to_culmination(matches, lon=lon)
+        matches = matches.sort_values(
+            by=[
+                "_listed_rank",
+                "_horizon_rank",
+                "_catalog_rank",
+                "_type_group_rank",
+                "_altitude_sort",
+                "_culm_abs_minutes",
+                "primary_id",
+            ],
+            ascending=[True, True, True, True, False, True, True],
+            kind="stable",
+        ).drop(
+            columns=[
+                "_listed_rank",
+                "_horizon_rank",
+                "_catalog_rank",
+                "_type_group_rank",
+                "_altitude_sort",
+                "_culm_abs_minutes",
+            ]
+        )
+    matches = matches.head(max_options)
+
+    options: list[tuple[str, str]] = []
+    for _, row in matches.iterrows():
+        primary_id = str(row.get("primary_id") or "")
+        options.append(
+            (
+                format_search_suggestion(row, is_listed=primary_id in listed_set, wind16_arrows=wind16_arrows),
+                primary_id,
+            )
+        )
+    return options

--- a/list_settings_ui.py
+++ b/list_settings_ui.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import pandas as pd
+import streamlit as st
+
+from list_subsystem import (
+    create_list,
+    delete_list,
+    editable_list_ids_in_order,
+    get_list_ids,
+    get_list_name,
+    is_system_list,
+    list_ids_in_order,
+    move_list,
+    rename_list,
+)
+
+
+def render_lists_settings_section(
+    prefs: dict[str, Any],
+    *,
+    persist_and_rerun_fn: Callable[[dict[str, Any]], None],
+) -> None:
+    st.subheader("Lists")
+    ordered_list_ids = list_ids_in_order(prefs, include_auto_recent=True)
+    if ordered_list_ids:
+        list_rows: list[dict[str, Any]] = []
+        for index, list_id in enumerate(ordered_list_ids, start=1):
+            list_rows.append(
+                {
+                    "Order": index,
+                    "List": get_list_name(prefs, list_id),
+                    "Items": len(get_list_ids(prefs, list_id)),
+                    "Type": "System" if is_system_list(prefs, list_id) else "Editable",
+                    "ID": list_id,
+                }
+            )
+        list_frame = pd.DataFrame(list_rows)
+        list_table_height = max(72, min(320, 36 * (len(list_frame) + 1)))
+        st.dataframe(
+            list_frame,
+            hide_index=True,
+            use_container_width=True,
+            height=list_table_height,
+        )
+    st.caption("`Auto (Recent)` is system-managed and tracks the last 10 search selections.")
+
+    create_cols = st.columns([3, 1], gap="small")
+    with create_cols[0]:
+        new_list_name = st.text_input("New list name", key="lists_new_name")
+    with create_cols[1]:
+        st.write("")
+        if st.button("Create list", key="lists_create_button", use_container_width=True):
+            created_list_id = create_list(prefs, new_list_name)
+            if created_list_id:
+                st.session_state["lists_manage_selected_id"] = created_list_id
+                st.session_state["lists_new_name"] = ""
+                persist_and_rerun_fn(prefs)
+            else:
+                st.warning("Enter a list name to create a new list.")
+
+    editable_list_ids = editable_list_ids_in_order(prefs)
+    if editable_list_ids:
+        manage_select_key = "lists_manage_selected_id"
+        current_manage_selection = str(st.session_state.get(manage_select_key, "")).strip()
+        if current_manage_selection not in editable_list_ids:
+            st.session_state[manage_select_key] = editable_list_ids[0]
+            current_manage_selection = editable_list_ids[0]
+
+        selected_manage_list_id = st.selectbox(
+            "Manage editable list",
+            options=editable_list_ids,
+            index=editable_list_ids.index(current_manage_selection),
+            key=manage_select_key,
+            format_func=lambda list_id: get_list_name(prefs, list_id),
+        )
+
+        manage_name_key = "lists_manage_name_input"
+        manage_name_for_id_key = "lists_manage_name_for_id"
+        if str(st.session_state.get(manage_name_for_id_key, "")).strip() != selected_manage_list_id:
+            st.session_state[manage_name_key] = get_list_name(prefs, selected_manage_list_id)
+            st.session_state[manage_name_for_id_key] = selected_manage_list_id
+
+        rename_value = st.text_input("Selected list name", key=manage_name_key)
+        selected_manage_idx = editable_list_ids.index(selected_manage_list_id)
+        control_cols = st.columns(4, gap="small")
+
+        if control_cols[0].button("Rename list", key="lists_rename_button", use_container_width=True):
+            if rename_list(prefs, selected_manage_list_id, rename_value):
+                persist_and_rerun_fn(prefs)
+            else:
+                st.warning("List name unchanged or invalid.")
+
+        if control_cols[1].button(
+            "Move up",
+            key="lists_move_up_button",
+            use_container_width=True,
+            disabled=(selected_manage_idx == 0),
+        ):
+            if move_list(prefs, selected_manage_list_id, -1):
+                persist_and_rerun_fn(prefs)
+
+        if control_cols[2].button(
+            "Move down",
+            key="lists_move_down_button",
+            use_container_width=True,
+            disabled=(selected_manage_idx >= (len(editable_list_ids) - 1)),
+        ):
+            if move_list(prefs, selected_manage_list_id, 1):
+                persist_and_rerun_fn(prefs)
+
+        if control_cols[3].button("Delete list", key="lists_delete_button", use_container_width=True):
+            if delete_list(prefs, selected_manage_list_id):
+                st.session_state.pop(manage_name_for_id_key, None)
+                st.session_state.pop(manage_name_key, None)
+                st.session_state.pop(manage_select_key, None)
+                persist_and_rerun_fn(prefs)
+            else:
+                st.warning("Could not delete that list.")
+    else:
+        st.caption("Create your first editable list to enable Add to list actions.")

--- a/list_subsystem.py
+++ b/list_subsystem.py
@@ -1,0 +1,440 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+import re
+from typing import Any
+
+AUTO_RECENT_LIST_ID = "auto_recent"
+AUTO_RECENT_LIST_NAME = "Auto (Recent)"
+AUTO_RECENT_LIST_MAX_ITEMS = 10
+DEFAULT_EDITABLE_LIST_ID = "targets"
+DEFAULT_EDITABLE_LIST_NAME = "Targets"
+
+
+def clean_primary_id_list(raw_values: Any) -> list[str]:
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    if not isinstance(raw_values, (list, tuple, set)):
+        return cleaned
+    for value in raw_values:
+        item = str(value).strip()
+        if not item or item in seen:
+            continue
+        cleaned.append(item)
+        seen.add(item)
+    return cleaned
+
+
+def default_lists_payload() -> dict[str, list[str]]:
+    return {
+        AUTO_RECENT_LIST_ID: [],
+        DEFAULT_EDITABLE_LIST_ID: [],
+    }
+
+
+def default_list_order() -> list[str]:
+    return [
+        AUTO_RECENT_LIST_ID,
+        DEFAULT_EDITABLE_LIST_ID,
+    ]
+
+
+def default_list_meta() -> dict[str, dict[str, Any]]:
+    return {
+        AUTO_RECENT_LIST_ID: {
+            "name": AUTO_RECENT_LIST_NAME,
+            "system": True,
+            "max_items": AUTO_RECENT_LIST_MAX_ITEMS,
+        },
+        DEFAULT_EDITABLE_LIST_ID: {
+            "name": DEFAULT_EDITABLE_LIST_NAME,
+            "system": False,
+        },
+    }
+
+
+def _merge_list_state_into_preferences(
+    prefs: dict[str, Any],
+    list_state: Mapping[str, Any],
+) -> None:
+    merged = dict(prefs)
+    for key, value in list_state.items():
+        merged[key] = value
+    prefs.clear()
+    prefs.update(merged)
+
+
+def _sanitize_list_name(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _slugify_list_id(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "_", str(value or "").strip().lower()).strip("_")
+    return slug
+
+
+def _build_unique_list_id(existing_ids: set[str], desired: str) -> str:
+    base = _slugify_list_id(desired) or "list"
+    candidate = base
+    suffix = 2
+    while candidate in existing_ids:
+        candidate = f"{base}_{suffix}"
+        suffix += 1
+    return candidate
+
+
+def normalize_list_preferences(raw: Mapping[str, Any] | None) -> dict[str, Any]:
+    lists_payload = default_lists_payload()
+    if isinstance(raw, Mapping):
+        raw_lists = raw.get("lists")
+        if isinstance(raw_lists, Mapping):
+            for raw_list_id, raw_ids in raw_lists.items():
+                list_id = str(raw_list_id).strip()
+                if not list_id:
+                    continue
+                lists_payload[list_id] = clean_primary_id_list(raw_ids)
+
+    lists_payload[AUTO_RECENT_LIST_ID] = lists_payload.get(AUTO_RECENT_LIST_ID, [])[-AUTO_RECENT_LIST_MAX_ITEMS:]
+
+    list_meta = default_list_meta()
+    for list_id in lists_payload:
+        if list_id not in list_meta:
+            list_meta[list_id] = {"name": list_id, "system": False}
+
+    raw_meta = raw.get("list_meta") if isinstance(raw, Mapping) else None
+    if isinstance(raw_meta, Mapping):
+        for raw_list_id, raw_entry in raw_meta.items():
+            list_id = str(raw_list_id).strip()
+            if not list_id or list_id not in lists_payload:
+                continue
+            if not isinstance(raw_entry, Mapping):
+                continue
+            name = str(raw_entry.get("name", "")).strip()
+            if name:
+                list_meta[list_id]["name"] = name
+            if list_id != AUTO_RECENT_LIST_ID:
+                list_meta[list_id]["system"] = bool(raw_entry.get("system", list_meta[list_id].get("system", False)))
+
+    list_meta[AUTO_RECENT_LIST_ID] = {
+        "name": AUTO_RECENT_LIST_NAME,
+        "system": True,
+        "max_items": AUTO_RECENT_LIST_MAX_ITEMS,
+    }
+
+    list_order: list[str] = []
+    seen_order: set[str] = set()
+    raw_order = raw.get("list_order") if isinstance(raw, Mapping) else None
+    if isinstance(raw_order, list):
+        for value in raw_order:
+            list_id = str(value).strip()
+            if not list_id or list_id in seen_order or list_id not in lists_payload:
+                continue
+            list_order.append(list_id)
+            seen_order.add(list_id)
+    for list_id in default_list_order():
+        if list_id in lists_payload and list_id not in seen_order:
+            list_order.append(list_id)
+            seen_order.add(list_id)
+    for list_id in lists_payload:
+        if list_id not in seen_order:
+            list_order.append(list_id)
+            seen_order.add(list_id)
+
+    raw_preview = raw.get("active_preview_list_id", AUTO_RECENT_LIST_ID) if isinstance(raw, Mapping) else AUTO_RECENT_LIST_ID
+    preview_list_id = str(raw_preview).strip()
+    if preview_list_id not in lists_payload:
+        preview_list_id = AUTO_RECENT_LIST_ID
+
+    return {
+        "lists": lists_payload,
+        "list_order": list_order,
+        "list_meta": list_meta,
+        "active_preview_list_id": preview_list_id,
+    }
+
+
+def all_listed_ids_in_order(prefs: Mapping[str, Any], *, include_auto_recent: bool = True) -> list[str]:
+    normalized = normalize_list_preferences(prefs)
+    lists_payload = normalized.get("lists", {})
+    if not isinstance(lists_payload, Mapping):
+        return []
+
+    seen: set[str] = set()
+    ordered_ids: list[str] = []
+    list_order = normalized.get("list_order", [])
+    if not isinstance(list_order, list):
+        list_order = []
+
+    def _append_list_items(list_id: str) -> None:
+        if not include_auto_recent and list_id == AUTO_RECENT_LIST_ID:
+            return
+        values = clean_primary_id_list(lists_payload.get(list_id, []))
+        for value in values:
+            if value in seen:
+                continue
+            ordered_ids.append(value)
+            seen.add(value)
+
+    for value in list_order:
+        list_id = str(value).strip()
+        if list_id:
+            _append_list_items(list_id)
+
+    for raw_list_id in lists_payload.keys():
+        list_id = str(raw_list_id).strip()
+        if list_id:
+            _append_list_items(list_id)
+
+    return ordered_ids
+
+
+def list_ids_in_order(prefs: Mapping[str, Any], *, include_auto_recent: bool = True) -> list[str]:
+    normalized = normalize_list_preferences(prefs)
+    lists_payload = normalized.get("lists", {})
+    if not isinstance(lists_payload, Mapping):
+        return []
+
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for value in normalized.get("list_order", []):
+        list_id = str(value).strip()
+        if not list_id or list_id in seen or list_id not in lists_payload:
+            continue
+        if not include_auto_recent and list_id == AUTO_RECENT_LIST_ID:
+            continue
+        ordered.append(list_id)
+        seen.add(list_id)
+
+    for raw_list_id in lists_payload:
+        list_id = str(raw_list_id).strip()
+        if not list_id or list_id in seen:
+            continue
+        if not include_auto_recent and list_id == AUTO_RECENT_LIST_ID:
+            continue
+        ordered.append(list_id)
+        seen.add(list_id)
+    return ordered
+
+
+def editable_list_ids_in_order(prefs: Mapping[str, Any]) -> list[str]:
+    return [
+        list_id
+        for list_id in list_ids_in_order(prefs, include_auto_recent=True)
+        if not is_system_list(prefs, list_id)
+    ]
+
+
+def get_list_ids(prefs: Mapping[str, Any], list_id: str) -> list[str]:
+    normalized = normalize_list_preferences(prefs)
+    cleaned_list_id = str(list_id).strip()
+    if not cleaned_list_id:
+        return []
+    return clean_primary_id_list(normalized.get("lists", {}).get(cleaned_list_id, []))
+
+
+def get_list_name(prefs: Mapping[str, Any], list_id: str) -> str:
+    normalized = normalize_list_preferences(prefs)
+    cleaned_list_id = str(list_id).strip()
+    if not cleaned_list_id:
+        return ""
+    raw_name = normalized.get("list_meta", {}).get(cleaned_list_id, {}).get("name", "")
+    resolved = str(raw_name).strip()
+    return resolved or cleaned_list_id
+
+
+def is_system_list(prefs: Mapping[str, Any], list_id: str) -> bool:
+    normalized = normalize_list_preferences(prefs)
+    cleaned_list_id = str(list_id).strip()
+    if not cleaned_list_id:
+        return False
+    return bool(normalized.get("list_meta", {}).get(cleaned_list_id, {}).get("system", False))
+
+
+def get_active_preview_list_id(prefs: Mapping[str, Any]) -> str:
+    normalized = normalize_list_preferences(prefs)
+    preview_list_id = str(normalized.get("active_preview_list_id", AUTO_RECENT_LIST_ID)).strip()
+    if preview_list_id in normalized.get("lists", {}):
+        return preview_list_id
+    return AUTO_RECENT_LIST_ID
+
+
+def set_active_preview_list_id(prefs: dict[str, Any], list_id: str) -> bool:
+    normalized = normalize_list_preferences(prefs)
+    next_list_id = str(list_id).strip()
+    if next_list_id not in normalized.get("lists", {}):
+        next_list_id = AUTO_RECENT_LIST_ID
+    if next_list_id == str(normalized.get("active_preview_list_id", AUTO_RECENT_LIST_ID)).strip():
+        return False
+    updated = dict(normalized)
+    updated["active_preview_list_id"] = next_list_id
+    reshaped = normalize_list_preferences(updated)
+    _merge_list_state_into_preferences(prefs, reshaped)
+    return True
+
+
+def create_list(prefs: dict[str, Any], name: str) -> str | None:
+    normalized = normalize_list_preferences(prefs)
+    cleaned_name = _sanitize_list_name(name)
+    if not cleaned_name:
+        return None
+
+    lists_payload = dict(normalized.get("lists", {}))
+    list_meta = dict(normalized.get("list_meta", {}))
+    list_order = list(normalized.get("list_order", []))
+    existing_ids = {str(list_id).strip() for list_id in lists_payload if str(list_id).strip()}
+    next_list_id = _build_unique_list_id(existing_ids, cleaned_name)
+    if not next_list_id:
+        return None
+
+    lists_payload[next_list_id] = []
+    list_meta[next_list_id] = {"name": cleaned_name, "system": False}
+    if next_list_id not in list_order:
+        list_order.append(next_list_id)
+
+    updated = dict(normalized)
+    updated["lists"] = lists_payload
+    updated["list_meta"] = list_meta
+    updated["list_order"] = list_order
+    reshaped = normalize_list_preferences(updated)
+    _merge_list_state_into_preferences(prefs, reshaped)
+    return next_list_id
+
+
+def rename_list(prefs: dict[str, Any], list_id: str, name: str) -> bool:
+    normalized = normalize_list_preferences(prefs)
+    cleaned_list_id = str(list_id).strip()
+    cleaned_name = _sanitize_list_name(name)
+    if not cleaned_list_id or not cleaned_name:
+        return False
+    if cleaned_list_id not in normalized.get("lists", {}):
+        return False
+    if is_system_list(normalized, cleaned_list_id):
+        return False
+
+    list_meta = dict(normalized.get("list_meta", {}))
+    current_entry = dict(list_meta.get(cleaned_list_id, {}))
+    current_name = str(current_entry.get("name", "")).strip()
+    if cleaned_name == current_name:
+        return False
+
+    current_entry["name"] = cleaned_name
+    current_entry["system"] = False
+    list_meta[cleaned_list_id] = current_entry
+
+    updated = dict(normalized)
+    updated["list_meta"] = list_meta
+    reshaped = normalize_list_preferences(updated)
+    _merge_list_state_into_preferences(prefs, reshaped)
+    return True
+
+
+def delete_list(prefs: dict[str, Any], list_id: str) -> bool:
+    normalized = normalize_list_preferences(prefs)
+    cleaned_list_id = str(list_id).strip()
+    if not cleaned_list_id:
+        return False
+    if cleaned_list_id not in normalized.get("lists", {}):
+        return False
+    if is_system_list(normalized, cleaned_list_id):
+        return False
+
+    lists_payload = dict(normalized.get("lists", {}))
+    list_meta = dict(normalized.get("list_meta", {}))
+    list_order = list(normalized.get("list_order", []))
+
+    lists_payload.pop(cleaned_list_id, None)
+    list_meta.pop(cleaned_list_id, None)
+    list_order = [value for value in list_order if str(value).strip() != cleaned_list_id]
+
+    updated = dict(normalized)
+    updated["lists"] = lists_payload
+    updated["list_meta"] = list_meta
+    updated["list_order"] = list_order
+    if str(updated.get("active_preview_list_id", "")).strip() == cleaned_list_id:
+        updated["active_preview_list_id"] = AUTO_RECENT_LIST_ID
+    reshaped = normalize_list_preferences(updated)
+    _merge_list_state_into_preferences(prefs, reshaped)
+    return True
+
+
+def move_list(prefs: dict[str, Any], list_id: str, direction: int) -> bool:
+    if direction not in {-1, 1}:
+        return False
+
+    normalized = normalize_list_preferences(prefs)
+    cleaned_list_id = str(list_id).strip()
+    if not cleaned_list_id:
+        return False
+    if cleaned_list_id not in normalized.get("lists", {}):
+        return False
+    if is_system_list(normalized, cleaned_list_id):
+        return False
+
+    all_order = list_ids_in_order(normalized, include_auto_recent=True)
+    user_order = [value for value in all_order if not is_system_list(normalized, value)]
+    if cleaned_list_id not in user_order:
+        return False
+
+    current_idx = user_order.index(cleaned_list_id)
+    next_idx = current_idx + direction
+    if next_idx < 0 or next_idx >= len(user_order):
+        return False
+
+    user_order[current_idx], user_order[next_idx] = user_order[next_idx], user_order[current_idx]
+    system_order = [value for value in all_order if is_system_list(normalized, value)]
+
+    updated = dict(normalized)
+    updated["list_order"] = system_order + user_order
+    reshaped = normalize_list_preferences(updated)
+    _merge_list_state_into_preferences(prefs, reshaped)
+    return True
+
+
+def toggle_target_in_list(prefs: dict[str, Any], list_id: str, primary_id: str) -> bool:
+    normalized = normalize_list_preferences(prefs)
+    cleaned_list_id = str(list_id).strip()
+    target_id = str(primary_id).strip()
+    if not cleaned_list_id or not target_id:
+        return False
+    lists_payload = dict(normalized.get("lists", {}))
+    if cleaned_list_id not in lists_payload:
+        return False
+
+    current_ids = clean_primary_id_list(lists_payload.get(cleaned_list_id, []))
+    if target_id in current_ids:
+        next_ids = [value for value in current_ids if value != target_id]
+    else:
+        next_ids = list(current_ids) + [target_id]
+    if cleaned_list_id == AUTO_RECENT_LIST_ID:
+        next_ids = next_ids[-AUTO_RECENT_LIST_MAX_ITEMS:]
+    if next_ids == current_ids:
+        return False
+
+    lists_payload[cleaned_list_id] = next_ids
+    updated = dict(normalized)
+    updated["lists"] = lists_payload
+    reshaped = normalize_list_preferences(updated)
+    _merge_list_state_into_preferences(prefs, reshaped)
+    return True
+
+
+def push_target_to_auto_recent_list(prefs: dict[str, Any], primary_id: str) -> bool:
+    target_id = str(primary_id).strip()
+    if not target_id:
+        return False
+
+    normalized = normalize_list_preferences(prefs)
+    lists_payload = dict(normalized.get("lists", {}))
+    current_auto_ids = clean_primary_id_list(lists_payload.get(AUTO_RECENT_LIST_ID, []))
+    next_auto_ids = [value for value in current_auto_ids if value != target_id]
+    next_auto_ids.append(target_id)
+    next_auto_ids = next_auto_ids[-AUTO_RECENT_LIST_MAX_ITEMS:]
+    if next_auto_ids == current_auto_ids:
+        return False
+
+    lists_payload[AUTO_RECENT_LIST_ID] = next_auto_ids
+    updated = dict(normalized)
+    updated["lists"] = lists_payload
+    reshaped = normalize_list_preferences(updated)
+    _merge_list_state_into_preferences(prefs, reshaped)
+    return True


### PR DESCRIPTION
## Summary
- replace Favorites/Set List behavior with a generic Lists subsystem and remove legacy set-list runtime paths
- add list_subsystem.py with list normalization + operations (create/rename/delete/reorder/toggle, preview-list selection, auto-recent FIFO)
- extract list-specific UI/logic from app.py into dedicated modules:
  - list_search.py (list-aware search ranking/options)
  - list_settings_ui.py (Settings Lists management section)
- update detail and Night Sky Preview flows to be list-driven, with target tips following summary-table highlight while detail target remains search-selected
- update README/TODO/PRD wording for the Lists model

## Validation
- PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile app.py list_subsystem.py list_search.py list_settings_ui.py target_tips/ui.py target_tips/engine.py
- quick local smoke checks for list helper behavior and search option generation via ./.venv/bin/python scripts
