### PR TITLE
Add baseline PR auto-labeling workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,37 @@
+area/app:
+- changed-files:
+  - any-glob-to-any-file:
+    - "app.py"
+    - "catalog_*.py"
+    - "list_*.py"
+    - "target_tips/**"
+    - "weather_service.py"
+
+area/data:
+- changed-files:
+  - any-glob-to-any-file:
+    - "data/**"
+
+area/docs:
+- changed-files:
+  - any-glob-to-any-file:
+    - "*.md"
+    - "docs/**"
+
+area/scripts:
+- changed-files:
+  - any-glob-to-any-file:
+    - "scripts/**"
+
+area/enricher:
+- changed-files:
+  - any-glob-to-any-file:
+    - "dso_enricher/**"
+
+area/infra:
+- changed-files:
+  - any-glob-to-any-file:
+    - ".github/**"
+    - ".gitignore"
+    - "requirements.txt"
+    - "runtime.txt"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,23 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels
+        uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true


### PR DESCRIPTION
## Summary
- add GitHub Actions labeler workflow for pull requests
- add label rules mapping changed paths to area/* labels
- establish baseline labels for automated triage

## Why
- reduces manual labeling effort
- keeps PR categorization consistent