### PR TITLE
Expand Observation Site location and obstruction workflows

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,6 +15,7 @@
 - [x] Improve reverse-geocode labels (city/state/country quality checks).
 - [ ] Add explicit permission-state messaging and retry flow.
 - [ ] Add location source badges (`default`, `manual`, `browser`, `ip`).
+- [ ] Add multi-site data model support (no UI yet): each site should store `name`, `location`, and `obstructions`, plus an active site pointer.
 
 ## Phase 3: Core Product Loop
 - [x] Search + results + target detail wired to live Alt/Az calculations.

--- a/app_constants.py
+++ b/app_constants.py
@@ -41,10 +41,10 @@ WIND16_ARROWS = {
 }
 
 DEFAULT_LOCATION: dict[str, Any] = {
-    "lat": 40.3573,
-    "lon": -74.6672,
-    "label": "Princeton, NJ",
-    "source": "default",
+    "lat": 0.0,
+    "lon": 0.0,
+    "label": "Location not set",
+    "source": "unset",
     "resolved_at": "",
 }
 

--- a/app_preferences.py
+++ b/app_preferences.py
@@ -62,6 +62,10 @@ def ensure_preferences_shape(raw: dict[str, Any]) -> dict[str, Any]:
         if isinstance(loc, dict):
             merged = copy.deepcopy(DEFAULT_LOCATION)
             merged.update({k: loc.get(k, merged[k]) for k in merged})
+            # Migrate legacy built-in default location payloads (source=default)
+            # to the new explicit "unset" state.
+            if str(merged.get("source", "")).strip().lower() == "default":
+                merged = copy.deepcopy(DEFAULT_LOCATION)
             prefs["location"] = merged
 
     return prefs

--- a/app_theme.py
+++ b/app_theme.py
@@ -57,6 +57,42 @@ def apply_ui_theme_css(theme_name: str) -> None:
                 .small-note {
                     font-size: 0.9rem;
                 }
+                .dso-location-meta {
+                    display: flex;
+                    align-items: center;
+                    gap: 0.4rem;
+                    flex-wrap: wrap;
+                    margin: 0.125rem 0 0.35rem 0;
+                    color: var(--dso-muted-text-color);
+                    font-size: 0.88rem;
+                    line-height: 1.2rem;
+                }
+                .dso-location-source-badge {
+                    display: inline-flex;
+                    align-items: center;
+                    padding: 0.05rem 0.5rem;
+                    border-radius: 999px;
+                    border: 1px solid transparent;
+                    font-size: 0.72rem;
+                    font-weight: 600;
+                    letter-spacing: 0.01em;
+                    line-height: 1.1rem;
+                }
+                .dso-location-source-badge--manual {
+                    background: rgba(34, 197, 94, 0.22);
+                    color: #bbf7d0;
+                    border-color: rgba(34, 197, 94, 0.45);
+                }
+                .dso-location-source-badge--browser {
+                    background: rgba(59, 130, 246, 0.22);
+                    color: #bfdbfe;
+                    border-color: rgba(59, 130, 246, 0.45);
+                }
+                .dso-location-source-badge--ip {
+                    background: rgba(245, 158, 11, 0.22);
+                    color: #fde68a;
+                    border-color: rgba(245, 158, 11, 0.45);
+                }
                 [data-testid="stDataFrame"] {
                     border: 1px solid var(--dso-border-color);
                     border-radius: 0.5rem;
@@ -115,6 +151,42 @@ def apply_ui_theme_css(theme_name: str) -> None:
             .small-note {
                 font-size: 0.9rem;
                 color: #666;
+            }
+            .dso-location-meta {
+                display: flex;
+                align-items: center;
+                gap: 0.4rem;
+                flex-wrap: wrap;
+                margin: 0.125rem 0 0.35rem 0;
+                color: #64748b;
+                font-size: 0.88rem;
+                line-height: 1.2rem;
+            }
+            .dso-location-source-badge {
+                display: inline-flex;
+                align-items: center;
+                padding: 0.05rem 0.5rem;
+                border-radius: 999px;
+                border: 1px solid transparent;
+                font-size: 0.72rem;
+                font-weight: 600;
+                letter-spacing: 0.01em;
+                line-height: 1.1rem;
+            }
+            .dso-location-source-badge--manual {
+                background: #dcfce7;
+                color: #166534;
+                border-color: #86efac;
+            }
+            .dso-location-source-badge--browser {
+                background: #dbeafe;
+                color: #1e40af;
+                border-color: #93c5fd;
+            }
+            .dso-location-source-badge--ip {
+                background: #fef3c7;
+                color: #92400e;
+                border-color: #fcd34d;
             }
             iframe[title^="streamlit_js_eval"] {
                 height: 0 !important;

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ requests>=2.31
 streamlit-js-eval>=1.0.0
 streamlit-vertical-slider>=2.5.5
 streamlit-extras>=0.4.0
+folium>=0.17
+streamlit-folium>=0.23


### PR DESCRIPTION
## Summary
This PR expands the `Site` experience and significantly improves how users set observation location and horizon obstructions.

The core outcomes are:
- A dedicated, richer `Observation Site` page flow for location + obstruction setup.
- Multiple obstruction input methods that all normalize to WIND16 at runtime.
- Better location UX (manual search, browser geolocation, IP fallback behavior, source badges, map-based selection).

## What Changed

### 1) Location defaults + migration behavior
- Removed hardcoded Princeton defaults from app defaults.
- New default location state is explicit `unset`:
  - `lat/lon = 0.0/0.0`
  - `label = "Location not set"`
  - `source = "unset"`
- Added migration behavior in preferences shape normalization:
  - legacy `source="default"` location payloads are migrated to the new `unset` default state.

Files:
- `app_constants.py`
- `app_preferences.py`

### 2) Location UI and interaction upgrades
- Refactored location settings into a dedicated section renderer.
- Added inline site-name editing via edit glyph (`✏️`) directly beside the site name.
- Reworked location input as a single search form:
  - `Location` text input with placeholder `enter an address, zip code, or landmark`
  - `Search` button
  - `🧭` browser geolocation button
  - Enter key in the text input submits search by default.
- Site-name preservation rule applied consistently:
  - If user has custom site name, location updates do **not** overwrite it.
  - If current name is default/unset, resolved location label can become site name.
- Added location source badges for lat/lon metadata:
  - `manual -> found`
  - `browser -> Browser`
  - `ip -> IP`
  - unset/unknown -> hidden badge.
- Added theme-aware badge styling for light and dark themes.
- Updated location copy to reflect source priority:
  - manual/browser first
  - IP fallback only.

Files:
- `app.py`
- `app_theme.py`

### 3) Map UX updates for location selection
- Map is now placed **below** the location form controls.
- Form area constrained to 30% width for tighter controls layout.
- Added interactive map selection capability:
  - User can right-click on map to set location.
  - Selected coordinates are reverse-geocoded and applied as location.
  - Preserves custom site naming rules.
- Implemented graceful fallback:
  - If interactive map dependency unavailable, falls back to static `st.map` rendering.

Files:
- `app.py`
- `requirements.txt`

### 4) Obstructions: three input modes (all normalize to WIND16)
Added a new multi-mode obstruction workflow in the Site page:

#### Mode A: `N/E/S/W (4 sliders)`
- User sets coarse cardinal obstructions.
- Values are expanded to WIND16 via linear interpolation across quadrants.
- Per latest UX tweak, NESW sliders default from the current WIND16 average.

#### Mode B: `WIND16 (16 sliders)`
- Existing detailed directional editing remains supported.
- Works with vertical slider UI; falls back to table editor if dependency unavailable.

#### Mode C: `Import .hrz file`
- Added `.hrz` file upload flow (compatible with APCC/N.I.N.A style data formats).
- Parser extracts azimuth/altitude pairs from file lines.
- Reducer bins points to WIND16 directions and takes max altitude per bin.
- Any missing bins keep prior WIND16 values and are reported to the user.

Net effect:
- Regardless of input method, app runtime uses/stores WIND16 obstructions only.

File:
- `app.py`

### 5) Site page structure improvements
- Added section frames around `Location` and `Obstructions` blocks for clearer visual grouping.
- Site page copy updated for clarity.

File:
- `app.py`

### 6) TODO tracking update
- Added TODO item to track future multi-site data model work:
  - site `name`, `location`, `obstructions`, and active site pointer.

File:
- `TODO.md`

### 7) New dependencies
- Added interactive map dependencies:
  - `folium>=0.17`
  - `streamlit-folium>=0.23`

File:
- `requirements.txt`

## Validation
Ran:
- `python3 -m py_compile app.py app_preferences.py app_constants.py app_theme.py weather_service.py condition_tips/engine.py`

Result: pass.

## Behavior Notes / Compatibility
- No change to obstruction runtime representation: still WIND16.
- Legacy users with old default location payloads are migrated to explicit `unset` location.
- Interactive right-click map selection is additive; fallback behavior preserves compatibility when folium components are unavailable.
