### PR TITLE
feat: move list management to dedicated Lists page

### DIFF
--- a/app.py
+++ b/app.py
@@ -4752,9 +4752,25 @@ def render_site_page(prefs: dict[str, Any]) -> None:
         render_obstructions_settings_section(prefs)
 
 
+def render_lists_page(prefs: dict[str, Any]) -> None:
+    st.title("Lists")
+    st.caption("Manage target lists used across explorer search, overlays, and detail actions.")
+
+    persistence_notice = st.session_state.get("prefs_persistence_notice", "")
+    if persistence_notice:
+        st.warning(persistence_notice)
+
+    with st.container(border=True):
+        render_lists_settings_section(
+            prefs,
+            persist_and_rerun_fn=persist_and_rerun,
+            show_subheader=False,
+        )
+
+
 def render_settings_page(catalog_meta: dict[str, Any], prefs: dict[str, Any], browser_locale: str | None) -> None:
     st.title("Settings")
-    st.caption("Manage display preferences, lists, catalog metadata, and settings backup.")
+    st.caption("Manage display preferences, catalog metadata, and settings backup.")
 
     persistence_notice = st.session_state.get("prefs_persistence_notice", "")
     if persistence_notice:
@@ -4779,9 +4795,6 @@ def render_settings_page(catalog_meta: dict[str, Any], prefs: dict[str, Any], br
     effective_unit = resolve_temperature_unit(selected_pref, browser_locale)
     source_note = "browser locale" if selected_pref == "auto" else "manual setting"
     st.caption(f"Active temperature unit: {effective_unit.upper()} ({source_note})")
-
-    st.divider()
-    render_lists_settings_section(prefs, persist_and_rerun_fn=persist_and_rerun)
 
     st.divider()
     st.subheader("Catalog")
@@ -6049,6 +6062,9 @@ def main() -> None:
     def site_page() -> None:
         render_site_page(prefs=prefs)
 
+    def lists_page() -> None:
+        render_lists_page(prefs=prefs)
+
     def settings_page() -> None:
         render_settings_page(
             catalog_meta=catalog_meta,
@@ -6061,15 +6077,19 @@ def main() -> None:
             [
                 st.Page(explorer_page, title="Explorer", icon="✨", default=True),
                 st.Page(site_page, title="Site", icon="📍"),
+                st.Page(lists_page, title="Lists", icon="📚"),
                 st.Page(settings_page, title="Settings", icon="⚙️"),
             ]
         )
         navigation.run()
         return
 
-    selected_page = st.sidebar.radio("Page", ["Explorer", "Site", "Settings"], key="app_page_selector")
+    selected_page = st.sidebar.radio("Page", ["Explorer", "Site", "Lists", "Settings"], key="app_page_selector")
     if selected_page == "Site":
         site_page()
+        return
+    if selected_page == "Lists":
+        lists_page()
         return
     if selected_page == "Settings":
         settings_page()

--- a/lists/list_settings_ui.py
+++ b/lists/list_settings_ui.py
@@ -22,8 +22,10 @@ def render_lists_settings_section(
     prefs: dict[str, Any],
     *,
     persist_and_rerun_fn: Callable[[dict[str, Any]], None],
+    show_subheader: bool = True,
 ) -> None:
-    st.subheader("Lists")
+    if show_subheader:
+        st.subheader("Lists")
     ordered_list_ids = list_ids_in_order(prefs, include_auto_recent=True)
     if ordered_list_ids:
         list_rows: list[dict[str, Any]] = []


### PR DESCRIPTION
## Summary
This PR moves list management out of **Settings** and into a new top-level **Lists** page in app navigation.

The goal is to separate list workflows from general app configuration so list operations are easier to find and manage.

## What Changed
- Added a new page renderer: `render_lists_page(...)` in `app.py`
  - Page title: `Lists`
  - Includes a bordered container for list operations
  - Reuses existing list management UI logic
- Updated app navigation to include **Lists**
  - `st.navigation(...)` path now has `Explorer`, `Site`, `Lists`, `Settings`
  - Sidebar radio fallback now has `Explorer`, `Site`, `Lists`, `Settings`
- Removed list management section from **Settings** page
  - Updated settings caption text to reflect new scope
  - `Settings` now focuses on display prefs, catalog metadata, and backup/restore
- Made list UI section reusable in multiple contexts
  - `lists/list_settings_ui.py`
  - Added optional parameter `show_subheader: bool = True`
  - `Lists` page calls it with `show_subheader=False` to avoid duplicate headings

## Files
- `app.py`
- `lists/list_settings_ui.py`

## Behavior Impact
- List management controls are no longer shown on `Settings`.
- Same list management functionality remains available under the new `Lists` page.
- No list data schema or persistence behavior changed.

## Validation
- Compile check passed:
  - `python3 -m py_compile app.py lists/list_settings_ui.py app_preferences.py app_constants.py`
- Attempted to run tests, but `pytest` is not installed in this environment (`pytest: command not found`).

## Notes
No migration needed. Existing preferences and lists continue to load as-is.
