### PR TITLE
Add filter bands for Seestar S30 telescope entries

### DIFF
--- a/data/equipment/equipment_catalog.json
+++ b/data/equipment/equipment_catalog.json
@@ -35,14 +35,20 @@
           "name": "ZWO Seestar S30 Pro",
           "fov_maj_deg": 4.3,
           "fov_min_deg": 2.4,
-          "filter_bands": []
+          "filter_bands": [
+            "HA",
+            "OIII"
+          ]
         },
         {
           "id": "zwo-seestar-s30",
           "name": "zwo Seestar S30",
           "fov_maj_deg": 2.14,
           "fov_min_deg": 1.21,
-          "filter_bands": []
+          "filter_bands": [
+            "HA",
+            "OIII"
+          ]
         },
         {
           "id": "dwarflab-dwarf-3",


### PR DESCRIPTION
## Summary
Adds missing telescope filter-band metadata for the two Seestar S30 entries in the equipment catalog.

## Changes
- Updated `data/equipment/equipment_catalog.json`:
  - `zwo-seestar-s30-pro`:
    - `filter_bands: ["HA", "OIII"]`
  - `zwo-seestar-s30`:
    - `filter_bands: ["HA", "OIII"]`

## Why
These entries previously had empty `filter_bands`, which caused them to appear incomplete relative to S50 metadata and reduced consistency for runtime equipment-driven filtering/scoring logic.

## Scope
- Data-only catalog update.
- No app logic or schema changes.

## Validation
- JSON formatting preserved/normalized.
- Diff is limited to `data/equipment/equipment_catalog.json`.
