### PR TITLE
Optimize recommendation query performance and recommendation-night UX

### DIFF
--- a/lists/list_settings_ui.py
+++ b/lists/list_settings_ui.py
@@ -49,6 +49,10 @@ def render_lists_settings_section(
         )
     st.caption("`Auto (Recent)` is system-managed and tracks the last 10 search selections.")
 
+    reset_new_name_key = "lists_new_name_reset"
+    if bool(st.session_state.pop(reset_new_name_key, False)):
+        st.session_state["lists_new_name"] = ""
+
     create_cols = st.columns([3, 1], gap="small")
     with create_cols[0]:
         new_list_name = st.text_input("New list name", key="lists_new_name")
@@ -58,7 +62,7 @@ def render_lists_settings_section(
             created_list_id = create_list(prefs, new_list_name)
             if created_list_id:
                 st.session_state["lists_manage_selected_id"] = created_list_id
-                st.session_state["lists_new_name"] = ""
+                st.session_state[reset_new_name_key] = True
                 persist_and_rerun_fn(prefs)
             else:
                 st.warning("Enter a list name to create a new list.")


### PR DESCRIPTION
## Summary
This PR improves recommendation-query performance by introducing layered caching and precomputed catalog features, removes the recommendation result cap, and updates the recommendation section title to include the selected night context.

It also includes a fix for list creation state handling to avoid a Streamlit session-state mutation error.

## What Changed

### 1) App-wide catalog caching
- Added a fingerprinted app-level catalog loader using `st.cache_resource`:
  - `_catalog_cache_fingerprint(...)`
  - `_load_catalog_resource_cached(...)`
  - `load_catalog_app_cached(...)`
- Catalog cache now rehydrates only when cache file mtime/size changes.

### 2) Catalog recommendation feature precompute (cached)
- Added cached precomputed recommendation feature frame:
  - `_load_catalog_recommendation_features_cached(...)`
  - `load_catalog_recommendation_features(...)`
- Precomputed fields include:
  - normalized object-type group
  - numeric RA/Dec + valid-coordinate flag
  - parsed emission-band token sets
  - apparent-size display and numeric sort key
  - target display name

### 3) Site/date AltAz bundle cache
- Added cached site/date transform bundle:
  - `_load_site_date_altaz_bundle_cached(...)`
  - `load_site_date_altaz_bundle(...)`
- Bundle includes:
  - altitude matrix
  - wind16 index matrix
  - per-target peak altitude/time/direction
  - sample-hour keys and primary-id -> matrix-column map
- Recommendation rendering now slices precomputed matrices for candidate subsets instead of recomputing full `SkyCoord -> AltAz` transforms each query.

### 4) Site/date weather-mask cache
- Added cached weather + cloud mask bundle:
  - `load_site_date_weather_mask_bundle(...)`
- Bundle includes:
  - weather rows
  - cloud cover map by hour
  - cloud-acceptable mask by sampled hour

### 5) Session-level recommendation query memo
- Added a session memo (`recommended_targets_query_cache`) keyed by a full criteria signature.
- Cached payload stores either:
  - `status=ok` + computed recommendation frame, or
  - `status=empty` + terminal empty-result message
- Added LRU-like trimming to keep cache bounded (`RECOMMENDATION_QUERY_SESSION_CACHE_LIMIT = 8`).

### 6) Cache hydration tracing in terminal
- Added trace utility:
  - `trace_cache_event(...)`
- Emits terminal logs when caches hydrate/hit for:
  - app catalog cache
  - recommendation feature cache
  - site/date AltAz cache
  - site/date weather-mask cache
  - session recommendation query cache hit/hydration

### 7) Remove max recommendation result cap
- Removed the 1000-row hard cap and associated warning branch.
- Recommendations are now unbounded (still paginated in UI).
- Updated criteria signature with `result_limit_mode: "unlimited"` so prior capped session entries are not reused.

### 8) Recommendation section title now includes selected night
- Added `format_recommendation_night_title(...)`.
- Updated header to:
  - `Recommended Targets for Tonight`
  - `Recommended Targets for Tomorrow Night`
  - `Recommended Targets for {Weekday} Night`
- Wired selected forecast day offset into `render_target_recommendations(...)`.

### 9) List creation Streamlit state fix
- In `lists/list_settings_ui.py`, replaced direct post-widget mutation of `lists_new_name` with a reset-flag pattern to avoid:
  - `StreamlitAPIException: st.session_state.<key> cannot be modified after widget ... is instantiated`

## Validation
- Compile checks passed:
  - `python3 -m py_compile app.py`
  - `python3 -m py_compile lists/list_settings_ui.py`

## Notes / Impact
- No persisted schema changes were introduced.
- Query behavior and ranking remain functionally consistent, but heavy recomputation is reduced significantly on repeated queries and reruns.
- UI pagination remains in place for result browsing despite removal of the hard cap.
