### PR TITLE
P1: Night rating UX + preview layout consistency

### DIFF
--- a/condition_tips/ui.py
+++ b/condition_tips/ui.py
@@ -46,6 +46,7 @@ def split_condition_tip_lines(tips: list[ConditionTip]) -> tuple[list[str], list
 def render_condition_tips_panel(
     *,
     title: str,
+    title_tooltip: str | None = None,
     period_label: str,
     forecast_date_text: str,
     hourly_weather_rows: list[dict[str, Any]],
@@ -53,7 +54,19 @@ def render_condition_tips_panel(
     temperature_unit: str,
     use_12_hour: bool,
 ) -> None:
-    st.markdown(f"##### {title}")
+    rendered_title = html.escape(str(title or "").strip() or "Conditions")
+    tooltip_text = str(title_tooltip or "").strip()
+    if tooltip_text:
+        tooltip_attr = html.escape(tooltip_text, quote=True).replace("\n", "&#10;")
+        st.markdown(
+            (
+                f"##### {rendered_title} "
+                f"<span title=\"{tooltip_attr}\" style=\"opacity:0.72; cursor:help;\">ⓘ</span>"
+            ),
+            unsafe_allow_html=True,
+        )
+    else:
+        st.markdown(f"##### {rendered_title}")
 
     context = ConditionTipsContext(
         period_label=period_label,


### PR DESCRIPTION
## Summary
This PR completes the active P1 work for night-rating UX and preview consistency, and includes the follow-up UI adjustments requested in-thread.

## What changed

### 1) Night rating system in Conditions title (Issue #82)
- Added weighted night rating computation from hourly weather:
  - Precipitation clear hours (`rain + showers + snowfall == 0`) at 40%
  - Cloud hours (`cloud_cover < 20%`) at 30%
  - Wind hours (`wind_gusts_10m`, fallback `wind_speed_10m`, converted to mph, `< 10 mph`) at 20%
  - Dew spread hours (`|temp - dewpoint| >= 3°` in active unit) at 10%
- Added 1..5 rating mapping and emoji mapping:
  - 1 `🚩🚩`, 2 `🚩`, 3 `⭐️`, 4 `⭐️⭐️`, 5 `⭐️⭐️🌟`
- Conditions panel title now appends rating emoji for selected night.
- Added a tooltip (`ⓘ`) beside title showing factor-level breakdown:
  - total weighted score
  - effective weights used (for missing-data scenarios)
  - per-factor weight + pass-rate + pass/data hours

### 2) UX improvements (Issue #89)
- Settings import now shows a success status summary after rerun with counts for:
  - sites imported
  - lists imported
  - equipment items imported
- Unobstructed altitude coverage plot labels removed (right-side line labels removed from this chart).
- Before target selection, the preview now consistently shows both plots side-by-side.

### 3) Layout consistency follow-up
- In no-target preview mode, plots are now rendered above the Targets table/tips (same ordering as selected-target mode).

### 4) Refresh cadence update follow-up
- Alt/Az auto-refresh changed from every 60 seconds to every 15 minutes.
- Status text updated to match (`Alt/Az auto-refresh 15m`).

## Validation
- `python3 -m py_compile app.py condition_tips/ui.py app_theme.py app_preferences.py`

## Notes
- Issue #84 was intentionally not included in this PR and remains open.

Closes #82
Closes #89
