### PR TITLE
Issue #90: Consolidate observation settings in sidebar

### DIFF
--- a/app_preferences.py
+++ b/app_preferences.py
@@ -125,6 +125,9 @@ def default_preferences() -> dict[str, Any]:
         "site_order": default_site_order(),
         "active_site_id": active_site_id,
         "equipment": {},
+        "active_telescope_id": "",
+        "active_filter_id": "__none__",
+        "active_mount_choice": "altaz",
         # Legacy convenience fields mirror the active site.
         "obstructions": copy.deepcopy(active_site["obstructions"]),
         "location": copy.deepcopy(active_site["location"]),
@@ -199,6 +202,13 @@ def ensure_preferences_shape(raw: dict[str, Any]) -> dict[str, Any]:
         prefs["site_order"] = site_order
         prefs["active_site_id"] = active_site_id
         prefs["equipment"] = _normalize_equipment(raw.get("equipment", {}))
+        prefs["active_telescope_id"] = str(raw.get("active_telescope_id", "")).strip()
+        raw_filter_id = str(raw.get("active_filter_id", "__none__")).strip()
+        prefs["active_filter_id"] = raw_filter_id if raw_filter_id else "__none__"
+        raw_mount_choice = str(raw.get("active_mount_choice", "altaz")).strip().lower()
+        if raw_mount_choice not in {"eq", "altaz"}:
+            raw_mount_choice = "altaz"
+        prefs["active_mount_choice"] = raw_mount_choice
 
         active_site = normalized_sites.get(active_site_id) or default_site_payload()
         prefs["location"] = copy.deepcopy(active_site.get("location", DEFAULT_LOCATION))

--- a/app_theme.py
+++ b/app_theme.py
@@ -343,6 +343,23 @@ def apply_ui_theme_css(theme_name: str) -> None:
     manual_badge = badges.get("manual", {})
     browser_badge = badges.get("browser", {})
     ip_badge = badges.get("ip", {})
+    sidebar_footer_css = f"""
+                [data-testid="stSidebarUserContent"] [data-testid="stVerticalBlock"] {{
+                    min-height: calc(100vh - 3.5rem);
+                    display: flex;
+                    flex-direction: column;
+                }}
+                [data-testid="stSidebarUserContent"] [data-testid="element-container"]:has(.dso-sidebar-theme-anchor) {{
+                    margin-top: auto;
+                    padding-top: 0.7rem;
+                    border-top: 1px solid {palette.get("border_color", "rgba(148, 163, 184, 0.35)")};
+                }}
+                .dso-sidebar-theme-anchor {{
+                    display: block;
+                    height: 0;
+                    width: 100%;
+                }}
+    """
     collapsed_sidebar_css = """
                 section[data-testid="stSidebar"][aria-expanded="false"],
                 [data-testid="stSidebar"][aria-expanded="false"] {{
@@ -428,6 +445,7 @@ def apply_ui_theme_css(theme_name: str) -> None:
                     color: var(--dso-text-color);
                 }}
 {collapsed_sidebar_css}
+{sidebar_footer_css}
                 [data-testid="stMainBlockContainer"],
                 [data-testid="stAppViewBlockContainer"] {{
                     padding-top: 1.15rem !important;
@@ -543,6 +561,7 @@ def apply_ui_theme_css(theme_name: str) -> None:
                     color: var(--dso-text-color);
                 }}
 {collapsed_sidebar_css}
+{sidebar_footer_css}
                 [data-testid="stMainBlockContainer"],
                 [data-testid="stAppViewBlockContainer"] {{
                     padding-top: 1.15rem !important;
@@ -632,6 +651,7 @@ def apply_ui_theme_css(theme_name: str) -> None:
                 color: {palette.get("small_note_color", "#666666")};
             }}
 {collapsed_sidebar_css}
+{sidebar_footer_css}
             [data-testid="stMainBlockContainer"],
             [data-testid="stAppViewBlockContainer"] {{
                 padding-top: 1.15rem !important;


### PR DESCRIPTION
## Summary
Implements issue #90 by moving active planning controls into a single sidebar experience and simplifying Explorer/Night Sky Preview control flow around those active settings.

Closes #90.

## What changed

### Sidebar: Observation settings (under nav)
- Added a new sidebar section titled **Observation settings** directly under navigation.
- Moved these active controls into it:
  - **Site** selector (sets active site)
  - **List** selector (sets active preview list used across explorer/preview)
  - **Camera Filter** selector (`None` + owned filters)
  - **Mount Choice** segmented control (`EQ` / `Alt/Az`, no `None`)
- Added/maintained telescope support in sidebar via equipment context:
  - If one owned telescope: show it as text
  - If multiple: selectable dropdown
- Theme control is now anchored at the bottom of the sidebar.

### Explorer / Observation Planner updates
- Removed the top-right site selector from the Observation Planner header.
- Recommendations panel controls now use include/adapt checkboxes:
  - **Include telescope details in recommendations**
  - **Include filter choice as criteria for recommendations**
  - **Adapt visibility calculations to selected mount**
- Recommendation engine now reads active sidebar settings for:
  - telescope context
  - filter hard-filter behavior
  - mount adaptation mode

### Night Sky Preview updates
- Removed Preview List selection widgets.
- Night Sky Preview now always renders using the active list chosen in sidebar Observation settings.

### Preferences/state updates
- Added persisted preference fields:
  - `active_telescope_id`
  - `active_filter_id` (supports `__none__`)
  - `active_mount_choice` (`eq` / `altaz`)
- Added normalization/sync helpers to keep active equipment selections valid against owned equipment.

### Styling updates
- Updated sidebar CSS anchoring so observation controls remain at the top and theme remains pinned to bottom.
- Fixed sidebar footer anchoring selector to avoid pushing all sidebar content downward.

## Files changed
- `app.py`
- `app_preferences.py`
- `app_theme.py`

## Validation
- `python3 -m py_compile app.py app_preferences.py app_theme.py`

## Notes
- No backwards-compatibility shims were added beyond normal preference-shape normalization for new keys.
- Existing behavior for users with no equipment remains: equipment-dependent controls hide or degrade gracefully.
