### PR TITLE
Adjust recommendation ranking and apparent-size sorting

### DIFF
--- a/app.py
+++ b/app.py
@@ -2441,10 +2441,15 @@ def apparent_size_sort_key_arcmin(major_arcmin: Any, minor_arcmin: Any) -> float
 
     major_value = _coerce(major_arcmin)
     minor_value = _coerce(minor_arcmin)
-    candidates = [value for value in (major_value, minor_value) if value is not None]
-    if not candidates:
+    if major_value is None and minor_value is None:
         return -1.0
-    return float(max(candidates))
+    if major_value is None:
+        major_value = minor_value
+    if minor_value is None:
+        minor_value = major_value
+    if major_value is None or minor_value is None:
+        return -1.0
+    return float(major_value * minor_value)
 
 
 def format_description_preview(value: Any, max_chars: int = 100) -> str:
@@ -3409,10 +3414,10 @@ def render_target_recommendations(
                                 by=[
                                     "filter_match_tier",
                                     "visibility_bin_15",
-                                    "selected_visible_minutes",
                                     "peak_alt_band_10",
-                                    "peak_altitude",
                                     "sort_size_metric",
+                                    "selected_visible_minutes",
+                                    "peak_altitude",
                                     "primary_id",
                                 ],
                                 ascending=[False, False, False, False, False, False, True],


### PR DESCRIPTION
## Summary
Updates recommendation sorting rules and the apparent-size sort metric in Explorer recommendations.

## Changes
- Updated default recommendation ranking order to:
  1. `filter_match_tier` desc
  2. `visibility_bin_15` desc
  3. `peak_alt_band_10` desc
  4. `sort_size_metric` desc
  5. `selected_visible_minutes` desc
  6. `peak_altitude` desc
  7. `primary_id` asc

- Changed `apparent_size_sort_arcmin` calculation to use apparent area:
  - If both dimensions are present: `major * minor`
  - If only one dimension is present: square it (`value * value`)
  - If no valid size values: `-1.0`

## Behavior impact
- Recommendation ranking now prioritizes altitude band and size metric ahead of selected visible minutes.
- The **Apparent size** sort option in the recommended targets table now sorts by area-derived size rather than max axis length.

## Validation
- `python3 -m py_compile app.py`
