### PR TITLE
Hotfix: fix Streamlit Cloud install failure for st_mui_table

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ streamlit-js-eval>=1.0.0
 streamlit-vertical-slider>=2.5.5
 streamlit-extras>=0.4.0
 streamlit-modal>=0.1.2
-st_mui_table>=0.1.8
+st_mui_table>=0.0.6
 folium>=0.17
 streamlit-folium>=0.23


### PR DESCRIPTION
## Summary
- fix Streamlit Community Cloud dependency resolution failure
- update `st_mui_table` requirement to a published version range

## Changes
- `requirements.txt`
  - changed `st_mui_table>=0.1.8` to `st_mui_table>=0.0.6`

## Why
Streamlit Cloud failed during install because `st_mui_table>=0.1.8` is not available on PyPI (current published versions are `0.0.1` through `0.0.6`).

## Impact
- restores deploy/install compatibility on Streamlit Cloud
- no application logic changes

## Validation
- dependency spec now matches available published package versions

Fixes deployment install error for current main.
