### PR TITLE
Implement Google Drive cloud sync for settings and session state (#107)

### DIFF
--- a/.streamlit/secrets.toml.example
+++ b/.streamlit/secrets.toml.example
@@ -1,0 +1,23 @@
+# Copy this file to `.streamlit/secrets.toml` and replace placeholders.
+# Do NOT commit the real `.streamlit/secrets.toml` file.
+
+[auth]
+# Local development redirect:
+redirect_uri = "http://localhost:8501/oauth2callback"
+
+# For Streamlit Community Cloud, use:
+# redirect_uri = "https://deep-space-object-explorer.streamlit.app/oauth2callback"
+
+# Generate a strong random secret and keep it private.
+cookie_secret = "REPLACE_WITH_RANDOM_COOKIE_SECRET"
+
+# Required for Google Drive sync (we need the access token in-app).
+expose_tokens = ["access"]
+
+[auth.google]
+client_id = "REPLACE_WITH_GOOGLE_CLIENT_ID"
+client_secret = "REPLACE_WITH_GOOGLE_CLIENT_SECRET"
+server_metadata_url = "https://accounts.google.com/.well-known/openid-configuration"
+
+# Keep scope minimal for now (Drive appDataFolder only).
+client_kwargs = { scope = "openid profile email https://www.googleapis.com/auth/drive.appdata", prompt = "select_account" }

--- a/README.md
+++ b/README.md
@@ -82,8 +82,26 @@ python scripts/ingest_catalog.py
 Notes:
 - The app uses `requirements.txt` automatically for Python dependencies.
 - `runtime.txt` pins Python to 3.11 for cloud parity.
-- Preferences persist in browser `localStorage` (not shared across users).
+- Preferences persist in browser `localStorage` by default; optional Google Drive sync can mirror prefs/session state.
 - For private repos, make sure Streamlit has GitHub access to this repository.
+
+Google sign-in + Drive appData sync setup:
+- Configure OIDC in `.streamlit/secrets.toml` with Google as provider.
+- Include `expose_tokens = ["access"]` and Drive appData scope.
+- Minimal example:
+
+```toml
+[auth]
+redirect_uri = "https://<your-app-url>/oauth2callback"
+cookie_secret = "<random-secret>"
+expose_tokens = ["access"]
+
+[auth.google]
+client_id = "<google-client-id>"
+client_secret = "<google-client-secret>"
+server_metadata_url = "https://accounts.google.com/.well-known/openid-configuration"
+client_kwargs = { scope = "openid profile email https://www.googleapis.com/auth/drive.appdata", prompt = "select_account" }
+```
 
 ## Release milestones
 

--- a/google_drive_sync.py
+++ b/google_drive_sync.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+import requests
+
+DRIVE_API_BASE = "https://www.googleapis.com/drive/v3"
+DRIVE_UPLOAD_BASE = "https://www.googleapis.com/upload/drive/v3"
+DEFAULT_SETTINGS_FILENAME = "dso_explorer_settings.json"
+
+
+def _auth_headers(access_token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {access_token}",
+    }
+
+
+def _request_json(
+    method: str,
+    url: str,
+    *,
+    access_token: str,
+    params: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+    data: bytes | str | None = None,
+    timeout_seconds: float = 20.0,
+) -> dict[str, Any]:
+    request_headers = _auth_headers(access_token)
+    if headers:
+        request_headers.update(headers)
+    response = requests.request(
+        method=method,
+        url=url,
+        params=params,
+        headers=request_headers,
+        data=data,
+        timeout=timeout_seconds,
+    )
+    if response.status_code >= 400:
+        raise RuntimeError(
+            f"Google Drive API error ({response.status_code}): {response.text[:300]}"
+        )
+    if not response.text:
+        return {}
+    payload = response.json()
+    if isinstance(payload, dict):
+        return payload
+    return {}
+
+
+def find_settings_file(
+    access_token: str,
+    *,
+    filename: str = DEFAULT_SETTINGS_FILENAME,
+) -> dict[str, Any] | None:
+    query = f"name = '{filename}' and 'appDataFolder' in parents and trashed = false"
+    payload = _request_json(
+        "GET",
+        f"{DRIVE_API_BASE}/files",
+        access_token=access_token,
+        params={
+            "q": query,
+            "spaces": "appDataFolder",
+            "pageSize": 1,
+            "fields": "files(id,name,modifiedTime,size)",
+            "orderBy": "modifiedTime desc",
+        },
+    )
+    files = payload.get("files", [])
+    if isinstance(files, list) and files:
+        first = files[0]
+        if isinstance(first, dict):
+            return first
+    return None
+
+
+def read_settings_payload(access_token: str, file_id: str) -> dict[str, Any] | None:
+    resolved_file_id = str(file_id).strip()
+    if not resolved_file_id:
+        return None
+    response = requests.get(
+        f"{DRIVE_API_BASE}/files/{resolved_file_id}",
+        params={"alt": "media"},
+        headers=_auth_headers(access_token),
+        timeout=20.0,
+    )
+    if response.status_code == 404:
+        return None
+    if response.status_code >= 400:
+        raise RuntimeError(
+            f"Google Drive API error ({response.status_code}): {response.text[:300]}"
+        )
+    payload = response.json()
+    if isinstance(payload, dict):
+        return payload
+    return None
+
+
+def _build_multipart_body(
+    metadata: dict[str, Any],
+    payload: dict[str, Any],
+) -> tuple[bytes, str]:
+    boundary = f"dso-explorer-{uuid.uuid4().hex}"
+    metadata_json = json.dumps(metadata, separators=(",", ":"), ensure_ascii=True)
+    payload_json = json.dumps(payload, separators=(",", ":"), ensure_ascii=True)
+    body = (
+        f"--{boundary}\r\n"
+        "Content-Type: application/json; charset=UTF-8\r\n\r\n"
+        f"{metadata_json}\r\n"
+        f"--{boundary}\r\n"
+        "Content-Type: application/json; charset=UTF-8\r\n\r\n"
+        f"{payload_json}\r\n"
+        f"--{boundary}--\r\n"
+    ).encode("utf-8")
+    return body, boundary
+
+
+def create_settings_file(
+    access_token: str,
+    payload: dict[str, Any],
+    *,
+    filename: str = DEFAULT_SETTINGS_FILENAME,
+) -> dict[str, Any]:
+    metadata = {
+        "name": filename,
+        "parents": ["appDataFolder"],
+        "mimeType": "application/json",
+    }
+    body, boundary = _build_multipart_body(metadata, payload)
+    return _request_json(
+        "POST",
+        f"{DRIVE_UPLOAD_BASE}/files",
+        access_token=access_token,
+        params={"uploadType": "multipart", "fields": "id,name,modifiedTime,size"},
+        headers={"Content-Type": f"multipart/related; boundary={boundary}"},
+        data=body,
+    )
+
+
+def update_settings_file(
+    access_token: str,
+    file_id: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    resolved_file_id = str(file_id).strip()
+    if not resolved_file_id:
+        raise ValueError("file_id is required")
+    metadata: dict[str, Any] = {"mimeType": "application/json"}
+    body, boundary = _build_multipart_body(metadata, payload)
+    return _request_json(
+        "PATCH",
+        f"{DRIVE_UPLOAD_BASE}/files/{resolved_file_id}",
+        access_token=access_token,
+        params={"uploadType": "multipart", "fields": "id,name,modifiedTime,size"},
+        headers={"Content-Type": f"multipart/related; boundary={boundary}"},
+        data=body,
+    )
+
+
+def upsert_settings_file(
+    access_token: str,
+    payload: dict[str, Any],
+    *,
+    preferred_file_id: str = "",
+    filename: str = DEFAULT_SETTINGS_FILENAME,
+) -> dict[str, Any]:
+    resolved_file_id = str(preferred_file_id).strip()
+    if resolved_file_id:
+        try:
+            return update_settings_file(
+                access_token,
+                resolved_file_id,
+                payload,
+            )
+        except Exception:
+            # Fall through to discover/create in case the file id was deleted or stale.
+            pass
+
+    existing = find_settings_file(access_token, filename=filename)
+    if existing and str(existing.get("id", "")).strip():
+        return update_settings_file(
+            access_token,
+            str(existing.get("id", "")).strip(),
+            payload,
+        )
+
+    return create_settings_file(
+        access_token,
+        payload,
+        filename=filename,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 streamlit>=1.40
+Authlib>=1.3.2
 streamlit-searchbox>=0.1.24
 streamlit-autorefresh>=1.0
 pandas>=2.0


### PR DESCRIPTION
## Summary
- add Google sign-in powered cloud sync using Google Drive appDataFolder
- sync preferences and a safe subset of session state across browsers/devices
- add Settings UI for sign-in/out, enable/disable sync, manual sync, and verbose sync diagnostics
- add local auth setup docs plus .streamlit/secrets.toml.example template

Closes #107

## What Was Implemented
- New google_drive_sync.py service module for Google Drive REST calls:
- find app settings file in appDataFolder
- read settings payload JSON
- create/update/upsert settings payload JSON
- Added cloud sync metadata fields in app_preferences.py:
- last_updated_utc
- cloud_sync_provider
- cloud_sync_enabled
- cloud_sync_initialized
- cloud_sync_file_id
- cloud_sync_last_ok_utc
- cloud_sync_last_error
- Updated save_preferences(...) to stamp local save time and mark cloud sync pending
- Added Google auth + sync orchestration in app.py
- Added Settings page Cloud Sync section
- Added Authlib>=1.3.2 dependency
- Added README.md and .streamlit/secrets.toml.example guidance for local/Streamlit Cloud OIDC setup

## Sync Semantics (Implemented)
- Storage location: Google Drive appDataFolder (hidden app storage)
- Conflict rule: latest timestamp wins (updated_at_utc)
- First sign-in behavior:
- if no remote settings file exists, seed cloud from current local settings/session state
- if remote exists and is newer, pull remote and apply locally
- Ongoing behavior:
- local preference saves mark a pending cloud sync
- cloud sync runs on rerun and uploads pending local changes
- refresh on another browser compares local vs remote and pulls newer remote state
- Sign-out behavior:
- stops cloud sync activity
- preserves local state

## Session State Sync Scope / Safety
- Syncs JSON-safe session state values only
- Excludes widget-managed and runtime-only keys that should not be restored
- Explicitly excludes recommendation query cache (recommended_targets_query_cache) from cloud snapshots

## Hardening / Bug Fixes Included
- Graceful fallback when Authlib is not installed (no crash; sign-in disabled + warning)
- Skip widget-locked keys during session restore instead of crashing (cannot be modified after widget...)
- Prevent malformed restored recommendation cache payloads from crashing recommendations
- Added verbose Cloud Sync diagnostics in Settings:
- local settings last saved
- last successful cloud sync
- latest remote payload timestamp seen
- latest Google Drive file modified time seen
- pending upload / bootstrapped state
- last compare result
- last sync action

## Local Validation Performed
- python3 -m py_compile app.py app_preferences.py google_drive_sync.py
- Local Google sign-in flow with .streamlit/secrets.toml configured
- Google Drive appData sync works after enabling Drive scope and API
- Two-browser test (same account):
- Browser 1 saves settings to cloud
- Browser 2 refresh pulls and restores newer settings
- Browser 2 changes settings/list membership
- Browser 1 refresh pulls without peak_time_local cache crash

## Setup Notes For Reviewers
- Requires Google OAuth/OIDC setup in .streamlit/secrets.toml or Streamlit Cloud secrets
- Must expose access token (expose_tokens = ["access"])
- Must request Drive appData scope: https://www.googleapis.com/auth/drive.appdata
- Google Drive API must be enabled in Google Cloud project

## Follow-ups (Out of Scope For This PR)
- Google Sheets export for lists (future additional scope/scopes)
- More granular sync conflict resolution beyond latest-timestamp-wins
- Explicit pull-vs-push UI actions (current Sync now triggers compare + sync flow)
