### PR TITLE
peformance improvements

### DIFF
--- a/ui/streamlit_app.py
+++ b/ui/streamlit_app.py
@@ -2046,6 +2046,7 @@ def approximate_location_from_ip() -> dict[str, Any] | None:
     return approximate_location_from_ip_feature()
 
 
+@st.cache_data(show_spinner=False, ttl=60 * 60 * 24 * 7)
 def fetch_free_use_image(search_phrase: str) -> dict[str, str] | None:
     if not search_phrase.strip():
         return None


### PR DESCRIPTION
## Summary
- Cache Wikimedia Commons image lookups used by recommendation thumbnails
- Reduces repeated network calls during Streamlit reruns (for example, opening/closing the target detail modal)

## Change
- Add `@st.cache_data(show_spinner=False, ttl=60 * 60 * 24 * 7)` to `fetch_free_use_image(...)`

## Verification
- `.venv/bin/python -m py_compile ui/streamlit_app.py`
