### PR TITLE
Add lunar forecast overlays and explorer site conditions refinements

### DIFF
--- a/features/condition_tips/ui.py
+++ b/features/condition_tips/ui.py
@@ -108,5 +108,20 @@ def render_condition_tips_panel(
         )
     if bullet_lines:
         st.markdown("\n".join(bullet_lines))
-    for muted_line in muted_lines:
-        st.caption(muted_line)
+    if muted_lines:
+        muted_html = "".join(
+            (
+                "<div style=\"margin:0.02rem 0; line-height:1.12;\">"
+                f"{_tip_text_html(muted_line)}"
+                "</div>"
+            )
+            for muted_line in muted_lines
+        )
+        st.markdown(
+            (
+                "<div style=\"color:#6b7280; font-size:0.88rem; margin-top:0.08rem;\">"
+                f"{muted_html}"
+                "</div>"
+            ),
+            unsafe_allow_html=True,
+        )

--- a/features/explorer/lunar.py
+++ b/features/explorer/lunar.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+LUNAR_PHASE_EMOJIS: dict[str, str] = {
+    "new": "🌑",
+    "first_quarter": "🌓",
+    "full": "🌕",
+    "third_quarter": "🌗",
+}
+
+
+def lunar_phase_emoji(phase_key: Any) -> str:
+    key = str(phase_key or "").strip().lower()
+    return LUNAR_PHASE_EMOJIS.get(key, "🌙")
+
+
+def lunar_altitude_row_label(phase_key: Any) -> str:
+    emoji = lunar_phase_emoji(phase_key)
+    return f"Lunar Altitude {emoji}".strip()
+
+
+def format_lunar_altitude_display(value: Any) -> str:
+    if value is None or pd.isna(value):
+        return "-"
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return "-"
+    if not np.isfinite(numeric):
+        return "-"
+    if numeric < 0.0:
+        return "-"
+    return f"{numeric:.1f} deg"
+
+
+def format_lunar_percent_display(value: Any) -> str:
+    if value is None or pd.isna(value):
+        return "-"
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return "-"
+    if not np.isfinite(numeric):
+        return "-"
+    if f"{numeric:.0f}%" == "0%":
+        return "-"
+    return f"{numeric:.0f}%"

--- a/runtime/lunar_ephemeris.py
+++ b/runtime/lunar_ephemeris.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import astropy.units as u
+import numpy as np
+import pandas as pd
+import streamlit as st
+from astral import moon as astral_moon
+from astropy.coordinates import AltAz, EarthLocation, get_body
+from astropy.time import Time
+
+from app_constants import WIND16
+
+_LUNAR_PHASE_ANCHORS: dict[str, tuple[float, str]] = {
+    "new": (0.0, "New Moon"),
+    "first_quarter": (7.38, "First Quarter"),
+    "full": (14.77, "Full Moon"),
+    "third_quarter": (22.15, "Third Quarter"),
+}
+_SYNODIC_MONTH_DAYS = 29.53
+
+
+def _empty_moon_track() -> pd.DataFrame:
+    return pd.DataFrame(
+        columns=["time_local", "alt", "az", "wind16", "min_alt_required", "visible"]
+    )
+
+
+def _parse_local_timestamp(value: str, tz_name: str) -> pd.Timestamp | None:
+    try:
+        parsed = pd.Timestamp(value)
+    except Exception:
+        return None
+
+    try:
+        tzinfo = ZoneInfo(str(tz_name or "UTC"))
+    except Exception:
+        tzinfo = ZoneInfo("UTC")
+
+    try:
+        if parsed.tzinfo is None:
+            return parsed.tz_localize(tzinfo)
+        return parsed.tz_convert(tzinfo)
+    except Exception:
+        return None
+
+
+def _az_to_wind16(azimuth_deg: float) -> str:
+    try:
+        azimuth = float(azimuth_deg) % 360.0
+    except (TypeError, ValueError):
+        return "N"
+    idx = int(((azimuth + 11.25) // 22.5) % 16)
+    return WIND16[idx]
+
+
+def _phase_key_from_age_days(age_days: float) -> tuple[str, str]:
+    try:
+        age = float(age_days)
+    except (TypeError, ValueError):
+        return "new", _LUNAR_PHASE_ANCHORS["new"][1]
+    if not np.isfinite(age):
+        return "new", _LUNAR_PHASE_ANCHORS["new"][1]
+
+    best_key = "new"
+    best_distance = float("inf")
+    for phase_key, (anchor, _label) in _LUNAR_PHASE_ANCHORS.items():
+        distance = abs(age - anchor)
+        distance = min(distance, _SYNODIC_MONTH_DAYS - distance)
+        if distance < best_distance:
+            best_distance = distance
+            best_key = phase_key
+    return best_key, _LUNAR_PHASE_ANCHORS[best_key][1]
+
+
+@st.cache_data(show_spinner=False, ttl=60 * 60 * 12)
+def compute_moon_track(
+    *,
+    lat: float,
+    lon: float,
+    tz_name: str,
+    start_local_iso: str,
+    end_local_iso: str,
+    sample_minutes: int = 10,
+) -> pd.DataFrame:
+    start_local = _parse_local_timestamp(start_local_iso, tz_name)
+    end_local = _parse_local_timestamp(end_local_iso, tz_name)
+    if start_local is None or end_local is None:
+        return _empty_moon_track()
+    if end_local < start_local:
+        return _empty_moon_track()
+
+    cadence_minutes = max(1, int(sample_minutes))
+    times_local = pd.date_range(
+        start=start_local,
+        end=end_local,
+        freq=f"{cadence_minutes}min",
+        inclusive="both",
+    )
+    if times_local.empty:
+        return _empty_moon_track()
+
+    try:
+        location = EarthLocation(lat=float(lat) * u.deg, lon=float(lon) * u.deg)
+    except Exception:
+        return _empty_moon_track()
+
+    times_utc = times_local.tz_convert("UTC")
+    astropy_times = Time(times_utc.to_pydatetime())
+
+    try:
+        moon_icrs = get_body("moon", astropy_times, location=location)
+        altaz_frame = AltAz(obstime=astropy_times, location=location)
+        moon_altaz = moon_icrs.transform_to(altaz_frame)
+    except Exception:
+        return _empty_moon_track()
+
+    altitudes = np.asarray(moon_altaz.alt.deg, dtype=float)
+    azimuths = np.asarray(moon_altaz.az.deg % 360.0, dtype=float)
+    visible = altitudes >= 0.0
+    winds = [_az_to_wind16(value) for value in azimuths.tolist()]
+
+    return pd.DataFrame(
+        {
+            "time_local": times_local,
+            "alt": altitudes,
+            "az": azimuths,
+            "wind16": winds,
+            "min_alt_required": np.zeros(len(times_local), dtype=float),
+            "visible": visible,
+        }
+    )
+
+
+@st.cache_data(show_spinner=False, ttl=60 * 60 * 12)
+def build_hourly_lunar_altitude_map(
+    *,
+    lat: float,
+    lon: float,
+    tz_name: str,
+    start_local_iso: str,
+    end_local_iso: str,
+    sample_minutes: int = 10,
+) -> dict[str, float]:
+    moon_track = compute_moon_track(
+        lat=lat,
+        lon=lon,
+        tz_name=tz_name,
+        start_local_iso=start_local_iso,
+        end_local_iso=end_local_iso,
+        sample_minutes=sample_minutes,
+    )
+    if moon_track.empty:
+        return {}
+
+    working = moon_track.copy()
+    time_values = pd.to_datetime(working["time_local"], errors="coerce")
+    altitude_values = pd.to_numeric(working["alt"], errors="coerce")
+    valid_mask = time_values.notna() & altitude_values.notna()
+    if not bool(valid_mask.any()):
+        return {}
+
+    working = working.loc[valid_mask].copy()
+    working["time_local"] = pd.to_datetime(working["time_local"], errors="coerce")
+    working["alt"] = pd.to_numeric(working["alt"], errors="coerce")
+    working = working.dropna(subset=["time_local", "alt"])
+    if working.empty:
+        return {}
+
+    working["hour_local"] = working["time_local"].dt.floor("h")
+    grouped = working.groupby("hour_local", sort=True)["alt"].mean()
+    result: dict[str, float] = {}
+    for hour_ts, avg_alt in grouped.items():
+        try:
+            numeric = float(avg_alt)
+        except (TypeError, ValueError):
+            continue
+        if not np.isfinite(numeric):
+            continue
+        result[pd.Timestamp(hour_ts).isoformat()] = numeric
+    return result
+
+
+@st.cache_data(show_spinner=False, ttl=60 * 60 * 24 * 30)
+def compute_lunar_phase_for_night(
+    *,
+    tz_name: str,
+    start_local_iso: str,
+    end_local_iso: str,
+) -> dict[str, str | float]:
+    start_local = _parse_local_timestamp(start_local_iso, tz_name)
+    end_local = _parse_local_timestamp(end_local_iso, tz_name)
+    if start_local is None or end_local is None:
+        return {"phase_key": "new", "phase_label": "New Moon", "phase_age_days": 0.0}
+    if end_local < start_local:
+        start_local, end_local = end_local, start_local
+
+    midpoint = start_local + (end_local - start_local) / 2
+    try:
+        phase_age_days = float(astral_moon.phase(midpoint.date()))
+    except Exception:
+        phase_age_days = 0.0
+    phase_key, phase_label = _phase_key_from_age_days(phase_age_days)
+    return {
+        "phase_key": phase_key,
+        "phase_label": phase_label,
+        "phase_age_days": phase_age_days,
+    }
+
+
+@st.cache_data(show_spinner=False, ttl=60 * 60 * 12)
+def compute_lunar_night_summary(
+    *,
+    lat: float,
+    lon: float,
+    tz_name: str,
+    start_local_iso: str,
+    end_local_iso: str,
+    sample_minutes: int = 10,
+) -> dict[str, int | float | None]:
+    hourly_altitude_map = build_hourly_lunar_altitude_map(
+        lat=lat,
+        lon=lon,
+        tz_name=tz_name,
+        start_local_iso=start_local_iso,
+        end_local_iso=end_local_iso,
+        sample_minutes=sample_minutes,
+    )
+    if not hourly_altitude_map:
+        return {
+            "hour_count": 0,
+            "moon_below_horizon_hours": 0,
+            "moon_below_horizon_pct": None,
+            "moon_avg_altitude_deg": None,
+            "moon_max_altitude_deg": None,
+        }
+
+    finite_values = [
+        float(value)
+        for value in hourly_altitude_map.values()
+        if value is not None and np.isfinite(float(value))
+    ]
+    if not finite_values:
+        return {
+            "hour_count": 0,
+            "moon_below_horizon_hours": 0,
+            "moon_below_horizon_pct": None,
+            "moon_avg_altitude_deg": None,
+            "moon_max_altitude_deg": None,
+        }
+
+    hour_count = int(len(finite_values))
+    below_horizon_hours = int(sum(1 for value in finite_values if float(value) < 0.0))
+    pct = (float(below_horizon_hours) / float(hour_count)) * 100.0 if hour_count > 0 else None
+    avg_altitude: float | None = None
+    max_altitude: float | None = None
+
+    # For Lunar-column coloring, use the exact astronomical-dark window samples
+    # (not the per-hour bucket averages) so partial edge hours are weighted
+    # correctly.
+    moon_track = compute_moon_track(
+        lat=lat,
+        lon=lon,
+        tz_name=tz_name,
+        start_local_iso=start_local_iso,
+        end_local_iso=end_local_iso,
+        sample_minutes=sample_minutes,
+    )
+    if isinstance(moon_track, pd.DataFrame) and not moon_track.empty:
+        track_times = pd.to_datetime(moon_track.get("time_local"), errors="coerce")
+        track_altitudes = pd.to_numeric(moon_track.get("alt"), errors="coerce")
+        sample_mask = track_times.notna() & track_altitudes.notna()
+        start_local = _parse_local_timestamp(start_local_iso, tz_name)
+        end_local = _parse_local_timestamp(end_local_iso, tz_name)
+        if start_local is not None and end_local is not None:
+            if end_local < start_local:
+                start_local, end_local = end_local, start_local
+            sample_mask &= (track_times >= start_local) & (track_times <= end_local)
+        if bool(sample_mask.any()):
+            sample_values = track_altitudes.loc[sample_mask].astype(float).to_numpy(dtype=float)
+            finite_sample_values = sample_values[np.isfinite(sample_values)]
+            if finite_sample_values.size > 0:
+                avg_altitude = float(np.mean(finite_sample_values))
+                max_altitude = float(np.max(finite_sample_values))
+
+    if avg_altitude is None and hour_count > 0:
+        avg_altitude = float(np.mean(finite_values))
+    if max_altitude is None and hour_count > 0:
+        max_altitude = float(np.max(finite_values))
+    return {
+        "hour_count": hour_count,
+        "moon_below_horizon_hours": below_horizon_hours,
+        "moon_below_horizon_pct": pct,
+        "moon_avg_altitude_deg": avg_altitude,
+        "moon_max_altitude_deg": max_altitude,
+    }

--- a/ui/streamlit_app.py
+++ b/ui/streamlit_app.py
@@ -388,7 +388,7 @@ WEATHER_MATRIX_ROWS: list[tuple[str, str]] = [
     ("visibility", "Visibility"),
     ("wind_gusts_10m", "Wind Gusts"),
 ]
-WEATHER_ALERT_INDICATOR_LEGEND_ITEMS = "❄️ Snow | ⛈️ Rain | ☔ Showers | ⚠️ 1-20% | 🚨 >20%"
+WEATHER_ALERT_INDICATOR_LEGEND_ITEMS = "❄️ Snow | ⛈️ Rain | ☔ Showers | ⚠️ Low | 🚨 High"
 WEATHER_ALERT_INDICATOR_LEGEND_CAPTION = f"Weather Alert Indicator: {WEATHER_ALERT_INDICATOR_LEGEND_ITEMS}"
 WEATHER_ALERT_RAIN_PRIORITY = ["❄️", "⛈️", "☔", "🚨", "⚠️"]
 WEATHER_ALERT_RAIN_INTERVAL_SECONDS = 5 * 60
@@ -1734,6 +1734,22 @@ def dew_risk_scale_legend_html() -> str:
         "<span style='margin-left:0.12rem;'>Dew</span>"
         "</div>"
     )
+
+
+def full_moon_scale_legend_html(*args: Any, **kwargs: Any):
+    from features.explorer.forecast_panels import (
+        full_moon_scale_legend_html as full_moon_scale_legend_html_feature,
+    )
+
+    return full_moon_scale_legend_html_feature(*args, **kwargs)
+
+
+def site_conditions_legends_table_html(*args: Any, **kwargs: Any):
+    from features.explorer.forecast_panels import (
+        site_conditions_legends_table_html as site_conditions_legends_table_html_feature,
+    )
+
+    return site_conditions_legends_table_html_feature(*args, **kwargs)
 
 
 def cloud_cover_cell_style(*args: Any, **kwargs: Any):


### PR DESCRIPTION
Closes #128

## Summary

This PR adds lunar impact visibility across the Explorer forecast and preview experience, and includes a set of follow-on UI refinements requested during implementation.

The result is that users can now see where the moon is, how high it will be, how it changes over the next five nights, and how it visually relates to the night sky preview plots without leaving the Explorer workflow.

## End-user features implemented

### 1. Hourly forecast now includes **Lunar Altitude**

Users will now see a dedicated `Lunar Altitude` row in the hourly forecast table (Site Conditions panel), alongside cloud cover, visibility, wind, humidity, and temperature.

Behavior and display details:
- Negative lunar altitude values (moon below horizon) display as `-`
- The row uses a **phase-aware grayscale background gradient**
  - very dark gray when the moon is at/below the horizon (`-` / 0°)
  - brighter gray as the moon gets higher in the sky
  - the top-end gray changes based on moon phase (new/quarter/full)
- The row label is plain `Lunar Altitude` (no emoji in the row title)
- Hover/tooltip formatting is aligned with the same lunar display rules

Hourly forecast row order was also refined to be more practical:
- `Cloud Cover`
- `Lunar Altitude`
- `Visibility`
- `Wind Gusts`
- `Humidity`
- `Temperature`

### 2. “Tonight” hourly forecast highlights the current/past hours

When the hourly forecast is showing **Tonight** (day offset 0):
- The current hour header (for example `8PM`) gets a yellow outline highlight
- Earlier hour headers get a subtle gray background
- Styling applies only to the **hour header cells**, not the entire column

This makes it easier to orient yourself in the forecast without visually overpowering the data cells.

### 3. 5-night forecast now includes a **Lunar** column

The 5-night astronomy forecast table now includes a `Lunar` column that shows the percentage of astronomical dark time when the moon is below the horizon.

Display behavior:
- `0%` displays as `-`
- When a phase emoji is shown and the value is zero, the cell displays **only the emoji** (no trailing `-`)
- Phase emoji appears at the **start of the Lunar cell** (not in the night label)

Phase icon rules:
- Night 1 shows the current phase emoji
- Later rows show a phase emoji only when the lunar phase bucket changes from the prior forecast night

### 4. 5-night Lunar cells are colorized using lunar altitude strength

The `Lunar` column is not only numeric; it is also colorized with the same lunar grayscale gradient logic used in the hourly `Lunar Altitude` row.

Coloring is based on the moon’s **maximum altitude during astronomical dark time** for that forecast night (while still preserving the average altitude calculation internally for future use). This provides a stronger visual cue for nights when the moon is high and impactful.

### 5. 5-night forecast column and header usability refinements

The 5-night forecast columns were reordered for readability and planning flow:
- `Clear`
- `Lunar`
- `Calm`
- `Crisp`
- `Dark Time`
- `Avg. Temp`

Additional header polish:
- `Dark` renamed to `Dark Time`
- Visible `Night` header text removed (blank first header cell)
- Column headers are bottom-aligned for a cleaner visual line-up

### 6. Night Sky Preview plots now show the moon path

Moon overlays were added to the Night Sky Preview visualizations, so users can compare target visibility with lunar position at a glance.

Added to:
- Cartesian path plot
- Radial path plot
- Unobstructed Altitude Coverage plot

### 7. Moon culmination marker (phase-appropriate emoji) on preview plots

Each moon overlay now includes a phase-appropriate moon emoji placed at the moon’s **culmination point** (highest altitude point in the displayed window).

This makes the lunar peak easy to identify visually without adding extra labels or clutter.

### 8. Site Conditions legend area redesigned into a compact key table

The legend/key area in Site Conditions was reorganized into a lightweight two-column table:
- left column labels are right-aligned
- right column keys are centered

Included rows:
- `Night Clarity`
- `Dew Risk`
- `Lunar Altitude` (renamed from `Lunar Phase`)
- `Weather Alerts`

Weather alert wording was also simplified from percentage-based labels to:
- `Low`
- `High`

### 9. Weather alert legend cleanup under the preview plot

Removed the weather alert indicator legend from under the unobstructed altitude coverage plot to reduce duplication and visual noise (the main legend remains in the Site Conditions section).

### 10. Site Conditions text polish

Small UX polish improvements requested during review:
- The “click an hour column header to search...” instruction was moved **below** the hourly forecast table
- Muted condition tips spacing was tightened for a denser, cleaner conditions panel

## Runtime / Features / UI organization (new model)

This implementation follows the current organizational model:

- `runtime/`
  - New `runtime/lunar_ephemeris.py` centralizes lunar ephemeris calculations, summaries, and caching
- `features/`
  - New `features/explorer/lunar.py` contains Explorer-facing lunar formatting helpers (display values, percent formatting, phase emoji helpers)
  - Explorer forecast/detail/plots modules consume runtime outputs and feature formatting helpers
- `ui/`
  - `ui/streamlit_app.py` only received thin compatibility wrapper updates where needed (no new core lunar computation logic added there)

## Validation

Completed:
- `py_compile` checks for all touched modules
- Runtime smoke checks for new lunar ephemeris helpers (including nightly summary values)

Not completed in this PR:
- Full interactive Streamlit UI smoke test / visual pass (recommended after merge to validate final spacing/color tuning on desktop and mobile)
