### PR TITLE
Enhance astronomy forecast controls and target summary table visuals

### DIFF
--- a/features/explorer/detail_panel.py
+++ b/features/explorer/detail_panel.py
@@ -238,6 +238,12 @@ def render_detail_panel(
                     {
                         "primary_id": preview_target_id,
                         "common_name": preview_common_name,
+                        "image_url": clean_text(preview_target.get("image_url")),
+                        "hero_image_url": clean_text(preview_target.get("hero_image_url")),
+                        "ra_deg": parse_numeric(preview_target.get("ra_deg")),
+                        "dec_deg": parse_numeric(preview_target.get("dec_deg")),
+                        "ang_size_maj_arcmin": parse_numeric(preview_target.get("ang_size_maj_arcmin")),
+                        "ang_size_min_arcmin": parse_numeric(preview_target.get("ang_size_min_arcmin")),
                         "label": preview_label,
                         "object_type_group": preview_group,
                         "emission_lines_display": preview_emission_details,
@@ -922,6 +928,12 @@ def render_detail_panel(
             {
                 "primary_id": preview_target_id,
                 "common_name": preview_common_name,
+                "image_url": clean_text(preview_target.get("image_url")),
+                "hero_image_url": clean_text(preview_target.get("hero_image_url")),
+                "ra_deg": parse_numeric(preview_target.get("ra_deg")),
+                "dec_deg": parse_numeric(preview_target.get("dec_deg")),
+                "ang_size_maj_arcmin": parse_numeric(preview_target.get("ang_size_maj_arcmin")),
+                "ang_size_min_arcmin": parse_numeric(preview_target.get("ang_size_min_arcmin")),
                 "label": preview_label,
                 "object_type_group": preview_group,
                 "emission_lines_display": preview_emission_details,
@@ -1096,6 +1108,15 @@ def render_detail_panel(
             selected_track=track,
             overlay_tracks=preview_tracks,
             list_member_ids=active_preview_list_members,
+            selected_metadata={
+                "common_name": clean_text(selected.get("common_name")),
+                "image_url": clean_text(selected.get("image_url")),
+                "hero_image_url": clean_text(selected.get("hero_image_url")),
+                "ra_deg": parse_numeric(selected.get("ra_deg")),
+                "dec_deg": parse_numeric(selected.get("dec_deg")),
+                "ang_size_maj_arcmin": parse_numeric(selected.get("ang_size_maj_arcmin")),
+                "ang_size_min_arcmin": parse_numeric(selected.get("ang_size_min_arcmin")),
+            },
             now_local=pd.Timestamp(datetime.now(tzinfo)),
             row_order_ids=(
                 [target_id] + [str(item) for item in active_preview_list_ids if str(item) != target_id]

--- a/ui/streamlit_app.py
+++ b/ui/streamlit_app.py
@@ -415,7 +415,7 @@ WEATHER_FORECAST_PERIOD_STATE_KEY = "weather_forecast_period"
 WEATHER_FORECAST_PERIOD_TONIGHT = "tonight"
 WEATHER_FORECAST_PERIOD_TOMORROW = "tomorrow"
 WEATHER_FORECAST_DAY_OFFSET_STATE_KEY = "weather_forecast_day_offset"
-ASTRONOMY_FORECAST_NIGHTS = 5
+ASTRONOMY_FORECAST_NIGHTS = 10
 NIGHT_RATING_FACTOR_WEIGHTS: dict[str, float] = {
     "precipitation": 0.05,
     "precip_probability": 0.10,
@@ -1407,6 +1407,7 @@ def build_sky_position_summary_rows(
     selected_track: pd.DataFrame | None,
     overlay_tracks: list[dict[str, Any]],
     list_member_ids: set[str],
+    selected_metadata: dict[str, Any] | None = None,
     now_local: pd.Timestamp | datetime | None = None,
     row_order_ids: list[str] | None = None,
 ) -> list[dict[str, Any]]:
@@ -1423,6 +1424,7 @@ def build_sky_position_summary_rows(
         selected_track=selected_track,
         overlay_tracks=overlay_tracks,
         list_member_ids=list_member_ids,
+        selected_metadata=selected_metadata,
         now_local=now_local,
         row_order_ids=row_order_ids,
     )


### PR DESCRIPTION
## Summary
This PR expands the earlier lunar-transition formatting update and now includes a broader set of Explorer forecast/table improvements:

- adds a forecast horizon segmented control (`5 nights` / `10 nights`) next to the `Astronomy Forecast` title
- updates forecast rendering/selection logic to respect the chosen horizon
- extends default forecast horizon to 10 nights
- improves Lunar-column emoji labeling so phase-defining nights are explicitly marked
- adds thumbnails to the `Targets` summary table using the same image resolution order as Recommended Targets search results
- adds size/framing metadata to the `Targets` summary table:
  - show `Framing` when an active telescope/FOV is available
  - otherwise show `Apparent size`
- aligns `Targets` thumbnail presentation with search results sizing/row height and keeps `Line` as the first column

## Details
### Astronomy Forecast controls
- `Astronomy Forecast` header now has an adjacent segmented control for horizon selection.
- The selected horizon is persisted in session state and used for:
  - summary build night count
  - day-offset clamping
  - forecast row selection normalization

### Lunar column emoji behavior
- transition rows continue to show `old_phase → new_phase`
- first row still shows the current phase emoji
- additionally, the row closest to each phase anchor age now receives that phase emoji label (phase-defining night), even if no transition occurs on that row

### Targets summary table enhancements
- added thumbnail column and resolver chain matching search results:
  1. catalog image URL(s)
  2. Wikimedia fallback
  3. survey cutout fallback
- added table metadata wiring from detail panel/summary rows for image and size/framing inputs
- added mutually exclusive size column behavior:
  - telescope selected + valid FOV: `Framing`
  - otherwise: `Apparent size`

## Validation
- `.venv/bin/python -m py_compile` passed for:
  - `features/explorer/detail_panel.py`
  - `features/explorer/forecast_panels.py`
  - `features/explorer/page_impl.py`
  - `features/explorer/summary_rows.py`
  - `features/explorer/summary_table.py`
  - `ui/streamlit_app.py`

## Changed Files
- `features/explorer/detail_panel.py`
- `features/explorer/forecast_panels.py`
- `features/explorer/page_impl.py`
- `features/explorer/summary_rows.py`
- `features/explorer/summary_table.py`
- `ui/streamlit_app.py`
